### PR TITLE
Impersonation client should have custom token mappers

### DIFF
--- a/src/main/java/org/folio/tm/integration/keycloak/model/ProtocolMapper.java
+++ b/src/main/java/org/folio/tm/integration/keycloak/model/ProtocolMapper.java
@@ -17,6 +17,7 @@ public class ProtocolMapper implements Serializable {
   public static final String USER_PROPERTY_MAPPER_TYPE = "oidc-usermodel-property-mapper";
   public static final String USER_ATTRIBUTE_MAPPER_TYPE = "oidc-usermodel-attribute-mapper";
   public static final String STRING_TYPE_LABEL = "String";
+  public static final String SUB_CLAIM = "sub";
 
   @Serial
   private static final long serialVersionUID = -68733298302690087L;

--- a/src/main/java/org/folio/tm/integration/keycloak/utils/KeycloakClientUtils.java
+++ b/src/main/java/org/folio/tm/integration/keycloak/utils/KeycloakClientUtils.java
@@ -1,0 +1,68 @@
+package org.folio.tm.integration.keycloak.utils;
+
+import static org.folio.tm.integration.keycloak.model.Client.OPENID_CONNECT_PROTOCOL;
+import static org.folio.tm.integration.keycloak.model.ProtocolMapper.STRING_TYPE_LABEL;
+import static org.folio.tm.integration.keycloak.model.ProtocolMapper.SUB_CLAIM;
+import static org.folio.tm.integration.keycloak.model.ProtocolMapper.USER_ATTRIBUTE_MAPPER_TYPE;
+import static org.folio.tm.integration.keycloak.model.ProtocolMapper.USER_PROPERTY_MAPPER_TYPE;
+
+import java.time.Instant;
+import java.util.List;
+import lombok.experimental.UtilityClass;
+import org.folio.tm.integration.keycloak.model.Client;
+import org.folio.tm.integration.keycloak.model.ProtocolMapper;
+
+@UtilityClass
+public class KeycloakClientUtils {
+
+  private static final String URIS = "/*";
+  private static final String USERNAME_PROPERTY = "username";
+  private static final String USER_ID_PROPERTY = "user_id";
+  private static final String USER_ID_MAPPER_NAME = "user_id mapper";
+
+  public static Client buildClient(String clientId, String clientSecret, String desc, List<ProtocolMapper> mappers,
+                                   boolean authEnabled, boolean serviceAccountEnabled) {
+    var attributes = buildClientAttributes();
+    return Client.builder()
+      .clientId(clientId)
+      .name(clientId)
+      .description(desc)
+      .secret(clientSecret)
+      .enabled(true)
+      .authorizationServicesEnabled(authEnabled)
+      .directAccessGrantsEnabled(true)
+      .serviceAccountsEnabled(serviceAccountEnabled)
+      .frontChannelLogout(true)
+      .redirectUris(List.of(URIS))
+      .webOrigins(List.of(URIS))
+      .attributes(attributes)
+      .protocolMappers(mappers)
+      .build();
+  }
+
+  public static List<ProtocolMapper> folioUserTokenMappers() {
+    var usernameMapper = protocolMapper(USER_PROPERTY_MAPPER_TYPE, USERNAME_PROPERTY, USERNAME_PROPERTY, SUB_CLAIM);
+    var userIdMapper =
+      protocolMapper(USER_ATTRIBUTE_MAPPER_TYPE, USER_ID_MAPPER_NAME, USER_ID_PROPERTY, USER_ID_PROPERTY);
+    return List.of(usernameMapper, userIdMapper);
+  }
+
+  public static Client.Attribute buildClientAttributes() {
+    return Client.Attribute.builder()
+      .oauth2DeviceAuthGrantEnabled(false)
+      .oidcCibaGrantEnabled(false)
+      .clientSecretCreationTime(Instant.now().getEpochSecond())
+      .backChannelLogoutSessionRequired(true)
+      .backChannelLogoutRevokeOfflineTokens(false)
+      .build();
+  }
+
+  public static ProtocolMapper protocolMapper(String mapperType, String mapperName, String userAttr, String claimName) {
+    return ProtocolMapper.builder()
+      .mapper(mapperType)
+      .protocol(OPENID_CONNECT_PROTOCOL)
+      .name(mapperName)
+      .config(ProtocolMapper.Config.of(true, true, true, userAttr, claimName, STRING_TYPE_LABEL))
+      .build();
+  }
+}

--- a/src/test/java/org/folio/tm/service/KeycloakImpersonationServiceTest.java
+++ b/src/test/java/org/folio/tm/service/KeycloakImpersonationServiceTest.java
@@ -39,19 +39,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class KeycloakImpersonationServiceTest {
 
-  @Mock
-  private ClientSecretService clientSecretService;
-  @Mock
-  private KeycloakPolicyService policyService;
-  @Mock
-  private KeycloakClientService clientService;
-  @Mock
-  private KeycloakPermissionService permissionService;
-  @Mock
-  private KeycloakRealmSetupProperties properties;
+  @Mock private ClientSecretService clientSecretService;
+  @Mock private KeycloakPolicyService policyService;
+  @Mock private KeycloakClientService clientService;
+  @Mock private KeycloakPermissionService permissionService;
+  @Mock private KeycloakRealmSetupProperties properties;
 
-  @InjectMocks
-  private KeycloakImpersonationService impersonationService;
+  @InjectMocks private KeycloakImpersonationService impersonationService;
 
   @BeforeEach
   public void setup() {

--- a/src/test/java/org/folio/tm/service/KeycloakImpersonationServiceTest.java
+++ b/src/test/java/org/folio/tm/service/KeycloakImpersonationServiceTest.java
@@ -1,5 +1,7 @@
 package org.folio.tm.service;
 
+import static org.folio.tm.integration.keycloak.model.ProtocolMapper.USER_ATTRIBUTE_MAPPER_TYPE;
+import static org.folio.tm.integration.keycloak.model.ProtocolMapper.USER_PROPERTY_MAPPER_TYPE;
 import static org.folio.tm.support.TestConstants.IMPERSONATE_CLIENT;
 import static org.folio.tm.support.TestConstants.IMPERSONATE_POLICY_ID;
 import static org.folio.tm.support.TestConstants.IMPERSONATE_SCOPE_ID;
@@ -10,12 +12,14 @@ import static org.folio.tm.support.TestConstants.SECRET;
 import static org.folio.tm.support.TestConstants.authorizationClientPolicy;
 import static org.folio.tm.support.TestConstants.authorizationImpersonationPermission;
 import static org.folio.tm.support.TestConstants.clientDescriptor;
+import static org.folio.tm.support.TestConstants.protocolMapper;
 import static org.folio.tm.support.TestConstants.scopePermission;
 import static org.folio.tm.support.TestConstants.userManagementPermission;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import org.folio.test.types.UnitTest;
 import org.folio.tm.integration.keycloak.ClientSecretService;
 import org.folio.tm.integration.keycloak.KeycloakClientService;
@@ -35,13 +39,19 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class KeycloakImpersonationServiceTest {
 
-  @Mock private ClientSecretService clientSecretService;
-  @Mock private KeycloakPolicyService policyService;
-  @Mock private KeycloakClientService clientService;
-  @Mock private KeycloakPermissionService permissionService;
-  @Mock private KeycloakRealmSetupProperties properties;
+  @Mock
+  private ClientSecretService clientSecretService;
+  @Mock
+  private KeycloakPolicyService policyService;
+  @Mock
+  private KeycloakClientService clientService;
+  @Mock
+  private KeycloakPermissionService permissionService;
+  @Mock
+  private KeycloakRealmSetupProperties properties;
 
-  @InjectMocks private KeycloakImpersonationService impersonationService;
+  @InjectMocks
+  private KeycloakImpersonationService impersonationService;
 
   @BeforeEach
   public void setup() {
@@ -57,8 +67,11 @@ class KeycloakImpersonationServiceTest {
     var policy = authorizationClientPolicy();
     policy.setId(IMPERSONATE_POLICY_ID);
 
-    var permission = authorizationImpersonationPermission();
     var impersonationClient = client(IMPERSONATE_CLIENT, "client for impersonating user");
+    impersonationClient.setProtocolMappers(List.of(
+      protocolMapper(USER_PROPERTY_MAPPER_TYPE, "username", "username", "sub"),
+      protocolMapper(USER_ATTRIBUTE_MAPPER_TYPE, "user_id mapper", "user_id", "user_id")
+    ));
 
     when(properties.getImpersonationClient()).thenReturn(IMPERSONATE_CLIENT);
     when(permissionService.enableUserPermissionsInRealm(REALM_NAME))
@@ -69,7 +82,7 @@ class KeycloakImpersonationServiceTest {
     when(policyService.createClientPolicy(authorizationClientPolicy(), REALM_NAME, REALM_MANAGEMENT_CLIENT_ID))
       .thenReturn(policy);
     doNothing().when(permissionService).updatePermission(REALM_NAME, REALM_MANAGEMENT_CLIENT_ID, IMPERSONATE_SCOPE_ID,
-      permission);
+      authorizationImpersonationPermission());
 
     impersonationService.setupImpersonationClient(REALM_NAME);
 

--- a/src/test/java/org/folio/tm/support/TestConstants.java
+++ b/src/test/java/org/folio/tm/support/TestConstants.java
@@ -197,6 +197,7 @@ public class TestConstants {
 
   public static Client clientDescriptor(String clientId, String clientSecret, String desc) {
     return Client.builder()
+      .name(clientId)
       .clientId(clientId)
       .description(desc)
       .secret(clientSecret)


### PR DESCRIPTION
## Purpose
When switching affiliation the token for another tenant is retrieved with impersonation-client, currently the client doesn't add custom token claims for user_id and username which are important for _self API. 

## Approach
- Add mappers
- Update tests

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
