### PR TITLE
MGRTENANT-32: Implement the ability to designate a tenant as "secure"

### DIFF
--- a/src/main/java/org/folio/tm/domain/entity/TenantEntity.java
+++ b/src/main/java/org/folio/tm/domain/entity/TenantEntity.java
@@ -45,6 +45,9 @@ public class TenantEntity extends Auditable implements Identifiable {
   @Column(name = "type", columnDefinition = "tenant_type")
   private TenantType type;
 
+  @Column(name = "is_secure", updatable = false)
+  private Boolean secure;
+
   @OrderBy("key")
   @Fetch(FetchMode.SUBSELECT)
   @OneToMany(cascade = CascadeType.ALL,

--- a/src/main/java/org/folio/tm/service/TenantService.java
+++ b/src/main/java/org/folio/tm/service/TenantService.java
@@ -66,14 +66,16 @@ public class TenantService {
 
   public Tenant updateTenantById(UUID id, Tenant tenant) {
     var existing = getOne(id);
-
     var tenantId = tenant.getId();
+
     if (!Objects.equals(existing.getId(), tenantId)) {
       throw new RequestValidationException("Tenant id doesn't match to the one in the path", "id", tenantId);
     }
-
     if (!Objects.equals(existing.getName(), tenant.getName())) {
       throw new RequestValidationException("Tenant name cannot be modified", "name", tenant.getName());
+    }
+    if (!Objects.equals(existing.getSecure(), tenant.getSecure())) {
+      throw new RequestValidationException("Secure field cannot be modified", "secure", tenant.getSecure());
     }
 
     var saved = repository.saveAndFlush(mapper.toEntity(tenant));

--- a/src/main/resources/changelog/changes/v1.0.0/add-secure-column.xml
+++ b/src/main/resources/changelog/changes/v1.0.0/add-secure-column.xml
@@ -4,7 +4,10 @@
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                    https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd">
 
-  <include file="changes/v1.0.0/create-tenant-table.xml" relativeToChangelogFile="true"/>
-  <include file="changes/v1.0.0/create-tenant-attr-table.xml" relativeToChangelogFile="true"/>
-  <include file="changes/v1.0.0/add-secure-column.xml" relativeToChangelogFile="true"/>
+  <changeSet id="add-secure-column" author="okuzminov">
+    <addColumn tableName="tenant">
+      <column name="is_secure" type="boolean"/>
+    </addColumn>
+  </changeSet>
+
 </databaseChangeLog>

--- a/src/main/resources/swagger.api/schemas/tenant.json
+++ b/src/main/resources/swagger.api/schemas/tenant.json
@@ -24,6 +24,10 @@
       "description": "Tenant type",
       "$ref": "tenantType.json"
     },
+    "secure": {
+      "description": "The flag shows whether the particular tenant is secure or not",
+      "type": "boolean"
+    },
     "attributes": {
       "description": "List of tenant attributes",
       "type": "array",


### PR DESCRIPTION
## Purpose
In order to support the [Congressional Loans functionality](https://folio-org.atlassian.net/browse/UXPROD-4119), we need a way to designate a tenant as “secure”.
[MGRTENANT-32](https://folio-org.atlassian.net/browse/MGRTENANT-32)
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant Rally issue, add a link directly to the issue URL here.
 -->

## Approach

- Add a new “secure” field to the tenant schema
  - type: boolean
  - required: no - should be optional for backwards compatibility
  - default: none, if a value is not specified when the tenant is created, the field should not be present in the tenant record.
  - read-only:  yes - this should be immutable.  Once the tenant is created it cannot be changed.
- Enforce the immutability of this field - return a 400 if a PUT request attempts to change this field.

<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## TODOS and Open Questions

<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

- [x] Check logging

## Learning

<!-- OPTIONAL
  Help out not only your reviewer but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries, or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [x] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
