### PR TITLE
Bump up applications-poc-tools dependencies to 1.5.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,13 +29,13 @@
     <mapstruct.version>1.6.0</mapstruct.version>
     <hypersistence-utils-hibernate-63.version>3.8.2</hypersistence-utils-hibernate-63.version>
     <swagger-annotations.version>2.2.23</swagger-annotations.version>
-    <apache-commons-lang3.version>3.14.0</apache-commons-lang3.version>
+    <apache-commons-lang3.version>3.17.0</apache-commons-lang3.version>
     <apache-commons-collections4.version>4.4</apache-commons-collections4.version>
     <cql2pgjson.version>35.2.2</cql2pgjson.version>
     <spring-cloud-bom.version>2023.0.3</spring-cloud-bom.version>
     <openapi-tools.jackson-databind-nullable.version>0.2.6</openapi-tools.jackson-databind-nullable.version>
     <folio-spring-cql.version>8.1.2</folio-spring-cql.version>
-    <applications-poc-tools.version>1.5.5</applications-poc-tools.version>
+    <applications-poc-tools.version>1.5.6</applications-poc-tools.version>
     <folio-java-checkstyle.version>1.0.1</folio-java-checkstyle.version>
 
     <mgr-tenants.yaml-file>${project.basedir}/src/main/resources/swagger.api/mgr-tenants.yaml</mgr-tenants.yaml-file>

--- a/src/main/java/org/folio/tm/integration/keycloak/configuration/KeycloakConfiguration.java
+++ b/src/main/java/org/folio/tm/integration/keycloak/configuration/KeycloakConfiguration.java
@@ -1,6 +1,6 @@
 package org.folio.tm.integration.keycloak.configuration;
 
-import static org.folio.common.utils.FeignClientTlsUtils.buildTargetFeignClient;
+import static org.folio.common.utils.tls.FeignClientTlsUtils.buildTargetFeignClient;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import feign.Contract;

--- a/src/test/java/org/folio/tm/it/DisableHostnameVerificationConfig.java
+++ b/src/test/java/org/folio/tm/it/DisableHostnameVerificationConfig.java
@@ -1,0 +1,13 @@
+package org.folio.tm.it;
+
+import static org.apache.commons.lang3.SystemProperties.JDK_INTERNAL_HTTP_CLIENT_DISABLE_HOST_NAME_VERIFICATION;
+
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class DisableHostnameVerificationConfig {
+
+  static {
+    System.setProperty(JDK_INTERNAL_HTTP_CLIENT_DISABLE_HOST_NAME_VERIFICATION, "true");
+  }
+}


### PR DESCRIPTION
## Purpose
Bump up applications-poc-tools dependencies to 1.5.6 to support Hostname Verification for TLS connections
