### PR TITLE
MGRTENANT-55: setup default keycloak realm session timeouts

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## Version `v3.1.0` (in progress)
+* Setup default keycloak realm session timeouts (MGRTENANT-55)
+
 ## Version `v3.0.0` (11.03.2025)
 * Upgrade Java to version 21. (MGRTENANT-49)
 * Entitlement issue for newly created tenant due to default keycloak configurations (MGRTENANT-47)

--- a/README.md
+++ b/README.md
@@ -128,6 +128,12 @@ The feature is controlled by two env variables `SECURITY_ENABLED` and `KC_INTEGR
 | KC_CLIENT_TLS_TRUSTSTORE_PATH     | -                            |    false    | Truststore file path for keycloak clients.                                                                                                              |
 | KC_CLIENT_TLS_TRUSTSTORE_PASSWORD | -                            |    false    | Truststore password for keycloak clients.                                                                                                               |
 | KC_CLIENT_TLS_TRUSTSTORE_TYPE     | -                            |    false    | Truststore file type for keycloak clients.                                                                                                              |
+| KC_ACCESS_TOKEN_TTL               | 300                          |    false    | Keycloak access token lifespan.                                                                                                                         |
+| KC_SSO_SESSION_IDLE_TTL           | 64800                        |    false    | Keycloak SSO session idle timeout.                                                                                                                      |
+| KC_SSO_SESSION_MAX_TTL            | 64800                        |    false    | Keycloak SSO session max lifespan.                                                                                                                      |
+| KC_CLIENT_SESSION_IDLE_TTL        | 64800                        |    false    | Keycloak client session idle timeout.                                                                                                                   |
+| KC_CLIENT_SESSION_MAX_TTL         | 64800                        |    false    | Keycloak client session max lifespan.                                                                                                                   |
+
 
 ### Interaction with Keycloak
 

--- a/src/main/java/org/folio/tm/integration/keycloak/KeycloakRealmService.java
+++ b/src/main/java/org/folio/tm/integration/keycloak/KeycloakRealmService.java
@@ -147,6 +147,12 @@ public class KeycloakRealmService {
         realm.getAttributes().put("parRequestUriLifespan", parRequestUriLifespan.toString());
       });
 
+    realm.setAccessTokenLifespan(keycloakRealmSetupProperties.getAccessTokenLifespan());
+    realm.setSsoSessionIdleTimeout(keycloakRealmSetupProperties.getSsoSessionIdleTimeout());
+    realm.setSsoSessionMaxLifespan(keycloakRealmSetupProperties.getSsoSessionMaxLifespan());
+    realm.setClientSessionIdleTimeout(keycloakRealmSetupProperties.getClientSessionIdleTimeout());
+    realm.setClientSessionMaxLifespan(keycloakRealmSetupProperties.getClientSessionMaxLifespan());
+
     return realm;
   }
 

--- a/src/main/java/org/folio/tm/integration/keycloak/KeycloakRealmService.java
+++ b/src/main/java/org/folio/tm/integration/keycloak/KeycloakRealmService.java
@@ -148,10 +148,10 @@ public class KeycloakRealmService {
       });
 
     realm.setAccessTokenLifespan(keycloakRealmSetupProperties.getAccessTokenLifespan());
-    realm.setSsoSessionIdleTimeout(keycloakRealmSetupProperties.getSsoSessionIdleTimeout());
-    realm.setSsoSessionMaxLifespan(keycloakRealmSetupProperties.getSsoSessionMaxLifespan());
-    realm.setClientSessionIdleTimeout(keycloakRealmSetupProperties.getClientSessionIdleTimeout());
-    realm.setClientSessionMaxLifespan(keycloakRealmSetupProperties.getClientSessionMaxLifespan());
+    realm.setSsoSessionIdleTimeout(keycloakRealmSetupProperties.getSsoSession().getIdleTimeout());
+    realm.setSsoSessionMaxLifespan(keycloakRealmSetupProperties.getSsoSession().getMaxLifespan());
+    realm.setClientSessionIdleTimeout(keycloakRealmSetupProperties.getClientSession().getIdleTimeout());
+    realm.setClientSessionMaxLifespan(keycloakRealmSetupProperties.getClientSession().getMaxLifespan());
 
     return realm;
   }

--- a/src/main/java/org/folio/tm/integration/keycloak/configuration/KeycloakRealmSetupProperties.java
+++ b/src/main/java/org/folio/tm/integration/keycloak/configuration/KeycloakRealmSetupProperties.java
@@ -20,10 +20,10 @@ public class KeycloakRealmSetupProperties {
   private String impersonationClient;
   private Integer accessCodeLifespan;
   private Integer parRequestUriLifespan;
-
   private Integer accessTokenLifespan;
-  private Integer ssoSessionIdleTimeout;
-  private Integer ssoSessionMaxLifespan;
-  private Integer clientSessionIdleTimeout;
-  private Integer clientSessionMaxLifespan;
+
+  @NestedConfigurationProperty
+  private KeycloakSessionProperties ssoSession = new KeycloakSessionProperties();
+  @NestedConfigurationProperty
+  private KeycloakSessionProperties clientSession = new KeycloakSessionProperties();
 }

--- a/src/main/java/org/folio/tm/integration/keycloak/configuration/KeycloakRealmSetupProperties.java
+++ b/src/main/java/org/folio/tm/integration/keycloak/configuration/KeycloakRealmSetupProperties.java
@@ -20,4 +20,10 @@ public class KeycloakRealmSetupProperties {
   private String impersonationClient;
   private Integer accessCodeLifespan;
   private Integer parRequestUriLifespan;
+
+  private Integer accessTokenLifespan;
+  private Integer ssoSessionIdleTimeout;
+  private Integer ssoSessionMaxLifespan;
+  private Integer clientSessionIdleTimeout;
+  private Integer clientSessionMaxLifespan;
 }

--- a/src/main/java/org/folio/tm/integration/keycloak/configuration/KeycloakSessionProperties.java
+++ b/src/main/java/org/folio/tm/integration/keycloak/configuration/KeycloakSessionProperties.java
@@ -1,0 +1,12 @@
+package org.folio.tm.integration.keycloak.configuration;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Data
+@ConfigurationProperties
+public class KeycloakSessionProperties {
+
+  private Integer idleTimeout;
+  private Integer maxLifespan;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -71,6 +71,11 @@ application:
         token_lifespan: ${KC_PASSWORD_RESET_TOKEN_TTL:86400}
       access-code-lifespan: ${KC_ACCESS_CODE_TTL:600}
       par-request-uri-lifespan: ${KC_PAR_REQUEST_URI_TTL:600}
+      access-token-lifespan: ${KC_ACCESS_TOKEN_TTL:300}
+      sso-session-idle-timeout: ${KC_SSO_SESSION_IDLE_TTL:64800}
+      sso-session-max-lifespan: ${KC_SSO_SESSION_MAX_TTL:64800}
+      client-session-idle-timeout: ${KC_CLIENT_SESSION_IDLE_TTL:64800}
+      client-session-max-lifespan: ${KC_CLIENT_SESSION_MAX_TTL:64800}
     tls:
       enabled: ${KC_CLIENT_TLS_ENABLED:false}
       trust-store-path: ${KC_CLIENT_TLS_TRUSTSTORE_PATH}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -72,10 +72,12 @@ application:
       access-code-lifespan: ${KC_ACCESS_CODE_TTL:600}
       par-request-uri-lifespan: ${KC_PAR_REQUEST_URI_TTL:600}
       access-token-lifespan: ${KC_ACCESS_TOKEN_TTL:300}
-      sso-session-idle-timeout: ${KC_SSO_SESSION_IDLE_TTL:64800}
-      sso-session-max-lifespan: ${KC_SSO_SESSION_MAX_TTL:64800}
-      client-session-idle-timeout: ${KC_CLIENT_SESSION_IDLE_TTL:64800}
-      client-session-max-lifespan: ${KC_CLIENT_SESSION_MAX_TTL:64800}
+      sso-session:
+        idle-timeout: ${KC_SSO_SESSION_IDLE_TTL:64800}
+        max-lifespan: ${KC_SSO_SESSION_MAX_TTL:64800}
+      client-session:
+        idle-timeout: ${KC_CLIENT_SESSION_IDLE_TTL:64800}
+        max-lifespan: ${KC_CLIENT_SESSION_MAX_TTL:64800}
     tls:
       enabled: ${KC_CLIENT_TLS_ENABLED:false}
       trust-store-path: ${KC_CLIENT_TLS_TRUSTSTORE_PATH}

--- a/src/test/java/org/folio/tm/it/TenantKeycloakIT.java
+++ b/src/test/java/org/folio/tm/it/TenantKeycloakIT.java
@@ -130,6 +130,11 @@ class TenantKeycloakIT extends BaseIntegrationTest {
     var realm = keycloakTestClient.getRealm(tenantName);
     assertThat(realm.getRealm()).isEqualTo(tenantName);
     checkImpersonationClient(tenantName);
+    assertThat(realm.getAccessTokenLifespan()).isEqualTo(261);
+    assertThat(realm.getSsoSessionIdleTimeout()).isEqualTo(262);
+    assertThat(realm.getSsoSessionMaxLifespan()).isEqualTo(263);
+    assertThat(realm.getClientSessionIdleTimeout()).isEqualTo(264);
+    assertThat(realm.getClientSessionMaxLifespan()).isEqualTo(265);
   }
 
   @Test

--- a/src/test/resources/application-it.yml
+++ b/src/test/resources/application-it.yml
@@ -27,10 +27,12 @@ application:
       trust-store-type: JKS
     realm-setup:
       access-token-lifespan: 261
-      sso-session-idle-timeout: 262
-      sso-session-max-lifespan: 263
-      client-session-idle-timeout: 264
-      client-session-max-lifespan: 265
+      sso-session:
+        idle-timeout: 262
+        max-lifespan: 263
+      client-session:
+        idle-timeout: 264
+        max-lifespan: 265
   secret-store:
     type: EPHEMERAL
     ephemeral:

--- a/src/test/resources/application-it.yml
+++ b/src/test/resources/application-it.yml
@@ -25,6 +25,12 @@ application:
       trust-store-path: classpath:certificates/test.truststore.jks
       trust-store-password: secretpassword
       trust-store-type: JKS
+    realm-setup:
+      access-token-lifespan: 261
+      sso-session-idle-timeout: 262
+      sso-session-max-lifespan: 263
+      client-session-idle-timeout: 264
+      client-session-max-lifespan: 265
   secret-store:
     type: EPHEMERAL
     ephemeral:


### PR DESCRIPTION
### **Purpose**
https://folio-org.atlassian.net/browse/MGRTENANT-55

Keycloak’s default values for session length are not suitable for Folio, given how RTR works.  Rather than relying on system operators to manually set this, the tenant manager should configure the new realm with more suitable default values.

### **Approach**
- update realm creation flow
- adjust test
- update README.md

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [x] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
