### PR TITLE
MGRTENANT-91: Upgrade dependencies for Kafka 4.2 compatibility in mgr-tenants

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+## Version `v4.1.0` (In Progress)
+* Upgrade dependencies for Kafka 4.2 compatibility in mgr-tenants (MGRTENANT-91)
+
+---
+
 ## Version `v4.0.0` (15.04.2026)
 * Setup default keycloak realm session timeouts (MGRTENANT-55)
 * Introduce configuration for FSSP (APPPOCTOOL-59)

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,9 @@
 
     <mgr-tenants.yaml-file>${project.basedir}/src/main/resources/swagger.api/mgr-tenants.yaml</mgr-tenants.yaml-file>
 
+    <!-- overrides Spring Boot BOM default; can be removed once Spring Boot ships this version -->
+    <kafka.version>4.2.0</kafka.version>
+
     <!-- Test dependencies versions -->
     <testcontainer.version>2.0.5</testcontainer.version>
 


### PR DESCRIPTION
### **Purpose**
Fix for https://folio-org.atlassian.net/browse/MGRTENANT-91

### **Approach**
Added the following to pom.xml - `<kafka.version>4.2.0</kafka.version>`
After the change, maven effective-pom shows 4.2.0 as the kafka version.

<img width="1066" height="1496" alt="image" src="https://github.com/user-attachments/assets/82e78d3f-edfd-40ec-98d9-a0daecc43db1" />


---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
