### PR TITLE
APPPOCTOOL-37: Switch Kong integration test container to folioci/folio-kong image

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## Version `v4.1.0` (In Progress)
 * Upgrade dependencies for Kafka 4.2 compatibility in mgr-tenants (MGRTENANT-91)
+* Switch Kong integration test container to folioci/folio-kong image (APPPOCTOOL-37)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Version 2.0. See the file "[LICENSE](LICENSE)" for more information.
     * [Folio Secure Store Proxy (FSSP)](#folio-secure-store-proxy-fssp)
     * [Kafka](#kafka)
 * [Keycloak Integration](#keycloak-integration)
+* [Integration Testing](#integration-testing)
 
 ## Introduction
 
@@ -203,5 +204,17 @@ curl -XDELETE \
 -H "Authorization: Bearer $token" \
 "$keycloakUrl/admin/realms/$tenantId"
 ```
+## Integration Testing
+
+Integration tests use Testcontainers for PostgreSQL and Kong. The following environment variables
+let you redirect containers to a private registry or adjust startup behaviour without changing
+source code.
+
+| Environment variable                     | Default                         | Description                          |
+|:-----------------------------------------|:--------------------------------|:-------------------------------------|
+| `TESTCONTAINERS_POSTGRES_IMAGE`          | `postgres:16-alpine`            | PostgreSQL container image           |
+| `TESTCONTAINERS_KONG_IMAGE`              | `folioci/folio-kong:latest`     | Kong container image                 |
+| `TESTCONTAINERS_KONG_READINESS_TIMEOUT`  | `120`                           | Seconds to wait for Kong startup     |
+
 ## AI Documentation
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/folio-org/mgr-tenants)

--- a/src/test/java/org/folio/tm/extension/impl/KongGatewayExtension.java
+++ b/src/test/java/org/folio/tm/extension/impl/KongGatewayExtension.java
@@ -1,8 +1,9 @@
 package org.folio.tm.extension.impl;
 
-import static java.time.Duration.ofSeconds;
+import static org.folio.test.extensions.impl.DockerImageRegistry.getKongImageName;
 import static org.folio.tm.extension.impl.PostgresContainerExtension.POSTGRES_NETWORK_ALIAS;
 
+import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.junit.jupiter.api.extension.AfterAllCallback;
@@ -10,26 +11,29 @@ import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
-import org.testcontainers.containers.startupcheck.OneShotStartupCheckStrategy;
+import org.testcontainers.containers.wait.strategy.Wait;
 
 public class KongGatewayExtension implements BeforeAllCallback, AfterAllCallback {
 
   public static final String KONG_GATEWAY_URL_PROPERTY = "kong.gateway.url";
-  public static final String KONG_DOCKER_IMAGE = "kong:3.9.1-ubuntu";
   public static final String KONG_URL_PROPERTY = "kong.url";
 
-  @SuppressWarnings("resource")
-  private static final GenericContainer<?> CONTAINER = new GenericContainer<>(KONG_DOCKER_IMAGE)
-    .withEnv(kongEnvironment())
-    .withNetwork(Network.SHARED)
-    .withExposedPorts(8000, 8001)
-    .withAccessToHost(true);
+  private static final String ENV_KONG_READINESS_TIMEOUT = "TESTCONTAINERS_KONG_READINESS_TIMEOUT";
+  private static final long DEFAULT_CONTAINER_READINESS_TIMEOUT = 120;
+
+  private static final long CONTAINER_READINESS_TIMEOUT;
+  private static final GenericContainer<?> CONTAINER;
+
+  static {
+    var env = System.getenv();
+    CONTAINER_READINESS_TIMEOUT = Long.parseLong(
+      env.getOrDefault(ENV_KONG_READINESS_TIMEOUT, String.valueOf(DEFAULT_CONTAINER_READINESS_TIMEOUT)));
+    CONTAINER = kongContainer(getKongImageName());
+  }
 
   @Override
   public void beforeAll(ExtensionContext extensionContext) {
     if (!CONTAINER.isRunning()) {
-      runMigrationWithContainer("kong migrations bootstrap");
-      runMigrationWithContainer("kong migrations up && kong migrations finish");
       CONTAINER.start();
     }
 
@@ -47,23 +51,20 @@ public class KongGatewayExtension implements BeforeAllCallback, AfterAllCallback
     return String.format("http://%s:%s", CONTAINER.getHost(), CONTAINER.getMappedPort(port));
   }
 
-  private static void runMigrationWithContainer(String command) {
-    try (var bootstrapMigrations = migrationContainer(command)) {
-      bootstrapMigrations.start();
-    } catch (Exception e) {
-      throw new RuntimeException("Failed to run kong migrations");
-    }
-  }
-
-  private static GenericContainer<?> migrationContainer(String command) {
-    return new GenericContainer<>(KONG_DOCKER_IMAGE)
-      .withEnv(kongMigrationEnvironment())
-      .withCommand(command)
+  @SuppressWarnings("resource")
+  private static GenericContainer<?> kongContainer(String imageName) {
+    return new GenericContainer<>(imageName)
+      .withEnv(kongEnvironment())
       .withNetwork(Network.SHARED)
-      .withStartupCheckStrategy(new OneShotStartupCheckStrategy().withTimeout(ofSeconds(5)));
+      .withExposedPorts(8000, 8001)
+      .withAccessToHost(true)
+      .waitingFor(Wait.forHttp("/status")
+        .forPort(8001)
+        .forStatusCode(200)
+        .withStartupTimeout(Duration.ofSeconds(CONTAINER_READINESS_TIMEOUT)));
   }
 
-  private static Map<String, String> kongMigrationEnvironment() {
+  private static Map<String, String> kongEnvironment() {
     var environment = new LinkedHashMap<String, String>();
 
     environment.put("KONG_DATABASE", "postgres");
@@ -72,16 +73,6 @@ public class KongGatewayExtension implements BeforeAllCallback, AfterAllCallback
     environment.put("KONG_PG_PASSWORD", "kong123");
     environment.put("KONG_PG_PORT", "5432");
     environment.put("KONG_PG_HOST", POSTGRES_NETWORK_ALIAS);
-    environment.put("KONG_ROUTER_FLAVOR", "expressions");
-
-    return environment;
-  }
-
-  private static Map<String, String> kongEnvironment() {
-    var environment = new LinkedHashMap<>(kongMigrationEnvironment());
-
-    environment.put("KONG_PROXY_ACCESS_LOG", "/dev/stdout");
-    environment.put("KONG_ADMIN_ACCESS_LOG", "/dev/stdout");
     environment.put("KONG_PROXY_ERROR_LOG", "/dev/stderr");
     environment.put("KONG_ADMIN_ERROR_LOG", "/dev/stderr");
     environment.put("KONG_PROXY_LISTEN", "0.0.0.0:8000");

--- a/src/test/java/org/folio/tm/extension/impl/KongGatewayExtension.java
+++ b/src/test/java/org/folio/tm/extension/impl/KongGatewayExtension.java
@@ -1,11 +1,17 @@
 package org.folio.tm.extension.impl;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
 import static org.folio.test.extensions.impl.DockerImageRegistry.getKongImageName;
 import static org.folio.tm.extension.impl.PostgresContainerExtension.POSTGRES_NETWORK_ALIAS;
 
+import java.net.HttpURLConnection;
+import java.net.URI;
 import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -20,6 +26,9 @@ public class KongGatewayExtension implements BeforeAllCallback, AfterAllCallback
 
   private static final String ENV_KONG_READINESS_TIMEOUT = "TESTCONTAINERS_KONG_READINESS_TIMEOUT";
   private static final long DEFAULT_CONTAINER_READINESS_TIMEOUT = 120;
+  // folioci/folio-kong runs migrations, starts Kong temporarily for deck sync, stops Kong,
+  // then restarts as the final foreground process. This log line appears just before the stop.
+  private static final String KONG_INIT_DONE_LOG = ".*Kong initialization finished successfully!.*\n";
 
   private static final long CONTAINER_READINESS_TIMEOUT;
   private static final GenericContainer<?> CONTAINER;
@@ -35,6 +44,7 @@ public class KongGatewayExtension implements BeforeAllCallback, AfterAllCallback
   public void beforeAll(ExtensionContext extensionContext) {
     if (!CONTAINER.isRunning()) {
       CONTAINER.start();
+      waitForKongFinalReady();
     }
 
     System.setProperty(KONG_URL_PROPERTY, getUrlForExposedPort(8001));
@@ -45,6 +55,38 @@ public class KongGatewayExtension implements BeforeAllCallback, AfterAllCallback
   public void afterAll(ExtensionContext extensionContext) {
     System.clearProperty(KONG_URL_PROPERTY);
     System.clearProperty(KONG_GATEWAY_URL_PROPERTY);
+  }
+
+  // Waits for the stop+restart cycle that folioci/folio-kong performs after deck sync.
+  // CONTAINER.start() returns when the init-done log line fires; Kong then briefly stops before
+  // coming back as the foreground process. We poll until we observe unavailable→available.
+  private static void waitForKongFinalReady() {
+    var wasUnavailable = new AtomicBoolean(false);
+    await()
+      .pollInterval(100, MILLISECONDS)
+      .atMost(30, SECONDS)
+      .until(() -> {
+        var available = CONTAINER.isRunning() && isKongStatusOk();
+        if (!available) {
+          wasUnavailable.set(true);
+        }
+        return available && wasUnavailable.get();
+      });
+  }
+
+  private static boolean isKongStatusOk() {
+    try {
+      var url = URI.create(getUrlForExposedPort(8001) + "/status").toURL();
+      var connection = (HttpURLConnection) url.openConnection();
+      connection.setConnectTimeout(500);
+      connection.setReadTimeout(500);
+      connection.setRequestMethod("GET");
+      var responseCode = connection.getResponseCode();
+      connection.disconnect();
+      return responseCode == 200;
+    } catch (Exception e) {
+      return false;
+    }
   }
 
   private static String getUrlForExposedPort(int port) {
@@ -58,9 +100,7 @@ public class KongGatewayExtension implements BeforeAllCallback, AfterAllCallback
       .withNetwork(Network.SHARED)
       .withExposedPorts(8000, 8001)
       .withAccessToHost(true)
-      .waitingFor(Wait.forHttp("/status")
-        .forPort(8001)
-        .forStatusCode(200)
+      .waitingFor(Wait.forLogMessage(KONG_INIT_DONE_LOG, 1)
         .withStartupTimeout(Duration.ofSeconds(CONTAINER_READINESS_TIMEOUT)));
   }
 

--- a/src/test/java/org/folio/tm/extension/impl/PostgresContainerExtension.java
+++ b/src/test/java/org/folio/tm/extension/impl/PostgresContainerExtension.java
@@ -1,6 +1,7 @@
 package org.folio.tm.extension.impl;
 
 import static java.lang.String.valueOf;
+import static org.folio.test.extensions.impl.DockerImageRegistry.getPostgresImageName;
 
 import java.util.UUID;
 import org.junit.jupiter.api.extension.AfterAllCallback;
@@ -15,7 +16,7 @@ public class PostgresContainerExtension implements BeforeAllCallback, AfterAllCa
   private static final String DB_HOST_PROPERTY = "DB_HOST";
   private static final String DB_PORT_PROPERTY = "DB_PORT";
 
-  private static final PostgreSQLContainer CONTAINER = new PostgreSQLContainer("postgres:16-alpine")
+  private static final PostgreSQLContainer CONTAINER = new PostgreSQLContainer(getPostgresImageName())
     .withDatabaseName("postgres")
     .withEnv("PG_USER", "postgres")
     .withUsername("postgres")


### PR DESCRIPTION
### Purpose

The vanilla `kong:3.9.1-ubuntu` image requires the application to spin up ephemeral migration containers before Kong starts, and several Kong configuration env vars must be set explicitly. Switching to `folioci/folio-kong:latest` eliminates that overhead: migrations run automatically inside the image's entrypoint, and router flavour, access log format, and the `auth-headers-manager` plugin are baked in.

US: [APPPOCTOOL-37](https://folio-org.atlassian.net/browse/APPPOCTOOL-37)

### Approach

Switched the Kong test container to the FOLIO-specific `folioci/folio-kong` image, which runs database migrations automatically and bakes in router configuration and access log settings. Both the Kong and Postgres images are now sourced from a central registry, making them overridable via environment variables.

- Switched the Kong container to `folioci/folio-kong:latest` (was `kong:3.9.1-ubuntu`), overridable via the `TESTCONTAINERS_KONG_IMAGE` environment variable.
- Removed the two migration containers that previously ran before Kong started — the folio-kong image handles this internally.
- Added an HTTP health check on the Kong admin status endpoint with a configurable startup timeout (120 s by default, overridable via `TESTCONTAINERS_KONG_READINESS_TIMEOUT`).
- Switched the Postgres container image to the central registry, making it overridable via `TESTCONTAINERS_POSTGRES_IMAGE`.

### Dependencies

> Requires [folio-org/applications-poc-tools#339](https://github.com/folio-org/applications-poc-tools/pull/339) to be merged and the updated `folio-backend-testing` artifact to be published before this PR can be merged.

### Pre-Review Checklist

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Dependent module build verification** — Ran manually when library changes impact downstream modules.
  > Actions → Verify Dependent Modules → Run workflow → select branch → Run.
- [ ] **Breaking Changes (if any)** — Handled if changes affect integration with other services.
- [x] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.