### PR TITLE
MGRTENANT-94: Keycloak - Configure Audience Mapper for New Tenant Login Clients

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ## Version `v4.1.0` (In Progress)
 * Upgrade dependencies for Kafka 4.2 compatibility in mgr-tenants (MGRTENANT-91)
 * Switch Kong integration test container to folioci/folio-kong image (APPPOCTOOL-37)
+* Add audience protocol mapper to the tenant login and impersonation clients so issued access tokens contain the login client in `aud` (MGRTENANT-94)
 
 ---
 

--- a/src/main/java/org/folio/tm/integration/keycloak/configuration/KeycloakRealmSetupProperties.java
+++ b/src/main/java/org/folio/tm/integration/keycloak/configuration/KeycloakRealmSetupProperties.java
@@ -27,4 +27,14 @@ public class KeycloakRealmSetupProperties {
   private KeycloakSessionProperties ssoSession = new KeycloakSessionProperties();
   @NestedConfigurationProperty
   private KeycloakSessionProperties clientSession = new KeycloakSessionProperties();
+
+  /**
+   * Builds the login client id for the given realm from the configured login client suffix.
+   *
+   * @param realm - Keycloak realm name
+   * @return login client id, e.g. {@code {realm}-login-application}
+   */
+  public String getLoginClientId(String realm) {
+    return realm + loginClient.getClientId();
+  }
 }

--- a/src/main/java/org/folio/tm/integration/keycloak/model/ProtocolMapper.java
+++ b/src/main/java/org/folio/tm/integration/keycloak/model/ProtocolMapper.java
@@ -17,6 +17,7 @@ public class ProtocolMapper implements Serializable {
   public static final String USER_PROPERTY_MAPPER_TYPE = "oidc-usermodel-property-mapper";
   public static final String USER_ATTRIBUTE_MAPPER_TYPE = "oidc-usermodel-attribute-mapper";
   public static final String SUB_MAPPER_TYPE = "oidc-sub-mapper";
+  public static final String AUDIENCE_MAPPER_TYPE = "oidc-audience-mapper";
   public static final String STRING_TYPE_LABEL = "String";
   public static final String SUB_CLAIM = "sub";
 

--- a/src/main/java/org/folio/tm/integration/keycloak/model/ProtocolMapperConfig.java
+++ b/src/main/java/org/folio/tm/integration/keycloak/model/ProtocolMapperConfig.java
@@ -20,6 +20,8 @@ public class ProtocolMapperConfig {
   public static final String ACCESS_TOKEN_CLAIM = "access.token.claim";
   public static final String USERINFO_TOKEN_CLAIM = "userinfo.token.claim";
   public static final String LIGHTWEIGHT_CLAIM = "lightweight.claim";
+  public static final String INTROSPECTION_TOKEN_CLAIM = "introspection.token.claim";
+  public static final String INCLUDED_CLIENT_AUDIENCE = "included.client.audience";
   public static final String USER_ATTRIBUTE = "user.attribute";
   public static final String CLAIM_NAME = "claim.name";
   public static final String JSON_TYPE_LABEL = "jsonType.label";

--- a/src/main/java/org/folio/tm/integration/keycloak/service/clients/AbstractKeycloakClientService.java
+++ b/src/main/java/org/folio/tm/integration/keycloak/service/clients/AbstractKeycloakClientService.java
@@ -154,10 +154,13 @@ public abstract class AbstractKeycloakClientService implements KeycloakClientSer
 
   /**
    * Defines a list with Keycloak client protocol mappers.
+   *
+   * @param realm - Keycloak realm name
+   * @param clientId - client identifier
    */
   @Nullable
   @SuppressWarnings("java:S1168")
-  protected List<ProtocolMapperRepresentation> getProtocolMappers() {
+  protected List<ProtocolMapperRepresentation> getProtocolMappers(String realm, String clientId) {
     return null;
   }
 
@@ -197,7 +200,7 @@ public abstract class AbstractKeycloakClientService implements KeycloakClientSer
     applyIfNotNull(getWebOrigins(), clientRepresentation::setWebOrigins);
     applyIfNotNull(getRedirectUris(), clientRepresentation::setRedirectUris);
     applyIfNotNull(getAttributes(), clientRepresentation::setAttributes);
-    applyIfNotNull(getProtocolMappers(), clientRepresentation::setProtocolMappers);
+    applyIfNotNull(getProtocolMappers(realm, clientId), clientRepresentation::setProtocolMappers);
     applyIfNotNull(getAuthorizationSettings(), clientRepresentation::setAuthorizationSettings);
 
     return clientRepresentation;

--- a/src/main/java/org/folio/tm/integration/keycloak/service/clients/ImpersonationClientService.java
+++ b/src/main/java/org/folio/tm/integration/keycloak/service/clients/ImpersonationClientService.java
@@ -3,10 +3,12 @@ package org.folio.tm.integration.keycloak.service.clients;
 import static jakarta.ws.rs.core.Response.Status.Family.SUCCESSFUL;
 import static java.lang.String.format;
 import static java.util.Collections.singleton;
+import static org.folio.tm.integration.keycloak.utils.KeycloakClientUtils.getAudienceProtocolMapper;
 import static org.folio.tm.integration.keycloak.utils.KeycloakClientUtils.getFolioUserTokenMappers;
 
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -57,8 +59,10 @@ public class ImpersonationClientService extends AbstractKeycloakClientService {
   }
 
   @Override
-  protected List<ProtocolMapperRepresentation> getProtocolMappers() {
-    return getFolioUserTokenMappers();
+  protected List<ProtocolMapperRepresentation> getProtocolMappers(String realm, String clientId) {
+    var protocolMappers = new ArrayList<>(getFolioUserTokenMappers());
+    protocolMappers.add(getAudienceProtocolMapper(keycloakRealmSetupProperties.getLoginClientId(realm)));
+    return protocolMappers;
   }
 
   @Override

--- a/src/main/java/org/folio/tm/integration/keycloak/service/clients/LoginClientService.java
+++ b/src/main/java/org/folio/tm/integration/keycloak/service/clients/LoginClientService.java
@@ -10,12 +10,14 @@ import static java.util.Map.entry;
 import static org.folio.common.utils.CollectionUtils.mapItems;
 import static org.folio.tm.integration.keycloak.service.roles.PasswordResetRoleService.PASSWORD_RESET_ROLE_NAME;
 import static org.folio.tm.integration.keycloak.service.roles.SystemRoleService.SYSTEM_ROLE_NAME;
+import static org.folio.tm.integration.keycloak.utils.KeycloakClientUtils.getAudienceProtocolMapper;
 import static org.folio.tm.integration.keycloak.utils.KeycloakClientUtils.getFolioUserTokenMappers;
 import static org.keycloak.representations.idm.authorization.DecisionStrategy.AFFIRMATIVE;
 import static org.keycloak.representations.idm.authorization.DecisionStrategy.UNANIMOUS;
 import static org.keycloak.representations.idm.authorization.Logic.POSITIVE;
 import static org.keycloak.representations.idm.authorization.PolicyEnforcementMode.ENFORCING;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -51,9 +53,7 @@ public class LoginClientService extends AbstractKeycloakClientService {
 
   @Override
   protected String getClientId(String realm) {
-    var loginClientConfiguration = keycloakRealmSetupProperties.getLoginClient();
-    var loginClientSuffix = loginClientConfiguration.getClientId();
-    return realm + loginClientSuffix;
+    return keycloakRealmSetupProperties.getLoginClientId(realm);
   }
 
   @Override
@@ -118,8 +118,10 @@ public class LoginClientService extends AbstractKeycloakClientService {
   }
 
   @Override
-  protected List<ProtocolMapperRepresentation> getProtocolMappers() {
-    return getFolioUserTokenMappers();
+  protected List<ProtocolMapperRepresentation> getProtocolMappers(String realm, String clientId) {
+    var protocolMappers = new ArrayList<>(getFolioUserTokenMappers());
+    protocolMappers.add(getAudienceProtocolMapper(clientId));
+    return protocolMappers;
   }
 
   private static ScopeRepresentation createScope(String name) {

--- a/src/main/java/org/folio/tm/integration/keycloak/service/clients/ModuleClientService.java
+++ b/src/main/java/org/folio/tm/integration/keycloak/service/clients/ModuleClientService.java
@@ -31,7 +31,7 @@ public class ModuleClientService extends AbstractKeycloakClientService {
   }
 
   @Override
-  protected List<ProtocolMapperRepresentation> getProtocolMappers() {
+  protected List<ProtocolMapperRepresentation> getProtocolMappers(String realm, String clientId) {
     return List.of(getSubjectProtocolMapper());
   }
 

--- a/src/main/java/org/folio/tm/integration/keycloak/service/clients/PasswordResetClientService.java
+++ b/src/main/java/org/folio/tm/integration/keycloak/service/clients/PasswordResetClientService.java
@@ -63,7 +63,7 @@ public class PasswordResetClientService extends AbstractKeycloakClientService {
   }
 
   @Override
-  protected List<ProtocolMapperRepresentation> getProtocolMappers() {
+  protected List<ProtocolMapperRepresentation> getProtocolMappers(String realm, String clientId) {
     return List.of(getPasswordResetProtocolMapper(), getSubjectProtocolMapper());
   }
 

--- a/src/main/java/org/folio/tm/integration/keycloak/utils/KeycloakClientUtils.java
+++ b/src/main/java/org/folio/tm/integration/keycloak/utils/KeycloakClientUtils.java
@@ -1,13 +1,21 @@
 package org.folio.tm.integration.keycloak.utils;
 
 import static org.folio.tm.integration.keycloak.model.Client.OPENID_CONNECT_PROTOCOL;
+import static org.folio.tm.integration.keycloak.model.ProtocolMapper.AUDIENCE_MAPPER_TYPE;
 import static org.folio.tm.integration.keycloak.model.ProtocolMapper.SUB_CLAIM;
 import static org.folio.tm.integration.keycloak.model.ProtocolMapper.SUB_MAPPER_TYPE;
 import static org.folio.tm.integration.keycloak.model.ProtocolMapper.USER_ATTRIBUTE_MAPPER_TYPE;
 import static org.folio.tm.integration.keycloak.model.ProtocolMapper.USER_PROPERTY_MAPPER_TYPE;
+import static org.folio.tm.integration.keycloak.model.ProtocolMapperConfig.ACCESS_TOKEN_CLAIM;
+import static org.folio.tm.integration.keycloak.model.ProtocolMapperConfig.ID_TOKEN_CLAIM;
+import static org.folio.tm.integration.keycloak.model.ProtocolMapperConfig.INCLUDED_CLIENT_AUDIENCE;
+import static org.folio.tm.integration.keycloak.model.ProtocolMapperConfig.INTROSPECTION_TOKEN_CLAIM;
+import static org.folio.tm.integration.keycloak.model.ProtocolMapperConfig.LIGHTWEIGHT_CLAIM;
+import static org.folio.tm.integration.keycloak.model.ProtocolMapperConfig.USERINFO_TOKEN_CLAIM;
 import static org.folio.tm.integration.keycloak.model.ProtocolMapperConfig.forUserAttribute;
 
 import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 import lombok.experimental.UtilityClass;
 import org.folio.tm.integration.keycloak.model.ProtocolMapperConfig;
@@ -20,6 +28,7 @@ public class KeycloakClientUtils {
   private static final String USER_ID_PROPERTY = "user_id";
   private static final String USER_ID_MAPPER_NAME = "user_id mapper";
   private static final String SUBJECT_MAPPER_NAME = "Subject (sub)";
+  private static final String AUDIENCE_MAPPER_NAME = "audience mapper";
 
   public static <T> void applyIfNotNull(T value, Consumer<T> valueConsumer) {
     if (value != null) {
@@ -39,6 +48,31 @@ public class KeycloakClientUtils {
     subjectMapper.setConfig(ProtocolMapperConfig.defaultValue().asMap());
 
     return subjectMapper;
+  }
+
+  /**
+   * Builds an audience protocol mapper adding the given client id to the 'aud' claim of issued tokens.
+   *
+   * <p>Required by Keycloak 26.6+ token introspection, which validates that the introspecting client is present
+   * in the token audience. The 'lightweight.claim' option keeps the claim in lightweight access tokens.</p>
+   *
+   * @param clientId - client identifier to include as audience
+   * @return audience {@link ProtocolMapperRepresentation} for the given client id
+   */
+  public static ProtocolMapperRepresentation getAudienceProtocolMapper(String clientId) {
+    var audienceMapper = new ProtocolMapperRepresentation();
+    audienceMapper.setName(AUDIENCE_MAPPER_NAME);
+    audienceMapper.setProtocolMapper(AUDIENCE_MAPPER_TYPE);
+    audienceMapper.setProtocol(OPENID_CONNECT_PROTOCOL);
+    audienceMapper.setConfig(Map.of(
+      INCLUDED_CLIENT_AUDIENCE, clientId,
+      ID_TOKEN_CLAIM, "false",
+      ACCESS_TOKEN_CLAIM, "true",
+      USERINFO_TOKEN_CLAIM, "false",
+      LIGHTWEIGHT_CLAIM, "true",
+      INTROSPECTION_TOKEN_CLAIM, "true"));
+
+    return audienceMapper;
   }
 
   private static ProtocolMapperRepresentation getUsernameProtocolMapper() {

--- a/src/test/java/org/folio/tm/integration/keycloak/service/clients/ImpersonationClientServiceTest.java
+++ b/src/test/java/org/folio/tm/integration/keycloak/service/clients/ImpersonationClientServiceTest.java
@@ -5,6 +5,7 @@ import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.folio.tm.support.TestConstants.AUTH_TOKEN;
 import static org.folio.tm.support.TestConstants.TENANT_NAME;
+import static org.folio.tm.support.TestConstants.audienceProtocolMapper;
 import static org.folio.tm.support.TestConstants.subjectProtocolMapper;
 import static org.folio.tm.support.TestConstants.userIdProtocolMapper;
 import static org.folio.tm.support.TestConstants.usernameProtocolMapper;
@@ -57,6 +58,7 @@ class ImpersonationClientServiceTest {
 
   private static final String IMPERSONATE_PERMISSION_ID = UUID.randomUUID().toString();
   private static final String CLIENT_ID = UUID.randomUUID().toString();
+  private static final String LOGIN_CLIENT_ID = TENANT_NAME + "-login-application";
   private static final String REALM_MGMT_CLIENT_ID = UUID.randomUUID().toString();
   private static final String CLIENT_SECRET = UUID.randomUUID().toString();
 
@@ -93,6 +95,7 @@ class ImpersonationClientServiceTest {
 
     when(keycloak.realm(TENANT_NAME)).thenReturn(realmResource);
     when(keycloakRealmSetupProperties.getImpersonationClient()).thenReturn("impersonation-client");
+    when(keycloakRealmSetupProperties.getLoginClientId(TENANT_NAME)).thenReturn(LOGIN_CLIENT_ID);
     when(clientSecretService.getOrCreateClientSecret(TENANT_NAME, "impersonation-client")).thenReturn(CLIENT_SECRET);
     when(keycloak.tokenManager().getAccessTokenString()).thenReturn(AUTH_TOKEN);
     when(realmResource.clients().create(clientCaptor.capture())).thenReturn(clientResponse);
@@ -142,6 +145,7 @@ class ImpersonationClientServiceTest {
     var internalServerErrorResponse = new ServerResponse(null, 500, new Headers<>());
 
     when(keycloakRealmSetupProperties.getImpersonationClient()).thenReturn("impersonation-client");
+    when(keycloakRealmSetupProperties.getLoginClientId(TENANT_NAME)).thenReturn(LOGIN_CLIENT_ID);
     when(keycloak.realm(TENANT_NAME)).thenReturn(realmResource);
     when(keycloak.tokenManager().getAccessTokenString()).thenReturn(AUTH_TOKEN);
     when(realmResource.clients().create(clientCaptor.capture())).thenReturn(internalServerErrorResponse);
@@ -167,6 +171,7 @@ class ImpersonationClientServiceTest {
     var userMgmtPermission = new UserManagementPermission(true);
 
     when(keycloakRealmSetupProperties.getImpersonationClient()).thenReturn("impersonation-client");
+    when(keycloakRealmSetupProperties.getLoginClientId(TENANT_NAME)).thenReturn(LOGIN_CLIENT_ID);
     when(keycloak.realm(TENANT_NAME)).thenReturn(realmResource);
     when(keycloak.tokenManager().getAccessTokenString()).thenReturn(AUTH_TOKEN);
     when(realmResource.clients().create(clientCaptor.capture())).thenThrow(InternalServerErrorException.class);
@@ -194,6 +199,7 @@ class ImpersonationClientServiceTest {
 
     when(keycloak.realm(TENANT_NAME)).thenReturn(realmResource);
     when(keycloakRealmSetupProperties.getImpersonationClient()).thenReturn("impersonation-client");
+    when(keycloakRealmSetupProperties.getLoginClientId(TENANT_NAME)).thenReturn(LOGIN_CLIENT_ID);
     when(clientSecretService.getOrCreateClientSecret(TENANT_NAME, "impersonation-client")).thenReturn(CLIENT_SECRET);
     when(keycloak.tokenManager().getAccessTokenString()).thenReturn(AUTH_TOKEN);
     when(realmResource.clients().create(clientCaptor.capture())).thenReturn(clientResponse);
@@ -221,6 +227,7 @@ class ImpersonationClientServiceTest {
     var internalServerErrorResponse = new ServerResponse(null, 500, new Headers<>());
 
     when(keycloakRealmSetupProperties.getImpersonationClient()).thenReturn("impersonation-client");
+    when(keycloakRealmSetupProperties.getLoginClientId(TENANT_NAME)).thenReturn(LOGIN_CLIENT_ID);
     when(keycloak.realm(TENANT_NAME)).thenReturn(realmResource);
     when(clientSecretService.getOrCreateClientSecret(TENANT_NAME, "impersonation-client")).thenReturn(CLIENT_SECRET);
     when(keycloak.tokenManager().getAccessTokenString()).thenReturn(AUTH_TOKEN);
@@ -251,6 +258,7 @@ class ImpersonationClientServiceTest {
     var clientResponse = new ServerResponse(null, 201, responseHeaders());
 
     when(keycloakRealmSetupProperties.getImpersonationClient()).thenReturn("impersonation-client");
+    when(keycloakRealmSetupProperties.getLoginClientId(TENANT_NAME)).thenReturn(LOGIN_CLIENT_ID);
     when(keycloak.realm(TENANT_NAME)).thenReturn(realmResource);
     when(clientSecretService.getOrCreateClientSecret(TENANT_NAME, "impersonation-client")).thenReturn(CLIENT_SECRET);
     when(keycloak.tokenManager().getAccessTokenString()).thenReturn(AUTH_TOKEN);
@@ -282,6 +290,7 @@ class ImpersonationClientServiceTest {
 
     when(keycloak.realm(TENANT_NAME)).thenReturn(realmResource);
     when(keycloakRealmSetupProperties.getImpersonationClient()).thenReturn("impersonation-client");
+    when(keycloakRealmSetupProperties.getLoginClientId(TENANT_NAME)).thenReturn(LOGIN_CLIENT_ID);
     when(clientSecretService.getOrCreateClientSecret(TENANT_NAME, "impersonation-client")).thenReturn(CLIENT_SECRET);
     when(keycloak.tokenManager().getAccessTokenString()).thenReturn(AUTH_TOKEN);
     when(realmResource.clients().create(clientCaptor.capture())).thenReturn(clientResponse);
@@ -342,7 +351,7 @@ class ImpersonationClientServiceTest {
     keycloakClient.setClientAuthenticatorType("client-secret");
     keycloakClient.setAttributes(new ClientAttributes(false, false, 0L, true, false, true, null, null).asMap());
     keycloakClient.setProtocolMappers(List.of(usernameProtocolMapper(), userIdProtocolMapper(),
-      subjectProtocolMapper()));
+      subjectProtocolMapper(), audienceProtocolMapper(LOGIN_CLIENT_ID)));
     keycloakClient.setServiceAccountsEnabled(true);
     keycloakClient.setDirectAccessGrantsEnabled(true);
     keycloakClient.setRedirectUris(List.of("/*"));

--- a/src/test/java/org/folio/tm/integration/keycloak/service/clients/LoginClientServiceTest.java
+++ b/src/test/java/org/folio/tm/integration/keycloak/service/clients/LoginClientServiceTest.java
@@ -11,6 +11,7 @@ import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.folio.common.utils.CollectionUtils.mapItems;
 import static org.folio.tm.support.TestConstants.TENANT_NAME;
+import static org.folio.tm.support.TestConstants.audienceProtocolMapper;
 import static org.folio.tm.support.TestConstants.subjectProtocolMapper;
 import static org.folio.tm.support.TestConstants.userIdProtocolMapper;
 import static org.folio.tm.support.TestConstants.usernameProtocolMapper;
@@ -31,7 +32,6 @@ import jakarta.ws.rs.InternalServerErrorException;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import org.folio.security.integration.keycloak.configuration.properties.KeycloakClientProperties;
 import org.folio.test.types.UnitTest;
 import org.folio.tm.integration.keycloak.ClientSecretService;
 import org.folio.tm.integration.keycloak.configuration.KeycloakRealmSetupProperties;
@@ -91,7 +91,7 @@ class LoginClientServiceTest {
   void setupClient_positive() {
     var clientResponse = new ServerResponse(null, 201, responseHeaders());
 
-    when(keycloakRealmSetupProperties.getLoginClient()).thenReturn(loginClientProperties());
+    when(keycloakRealmSetupProperties.getLoginClientId(TENANT_NAME)).thenReturn(CLIENT_ID);
     when(clientSecretService.getOrCreateClientSecret(TENANT_NAME, CLIENT_ID)).thenReturn(CLIENT_SECRET);
     when(keycloak.realm(TENANT_NAME)).thenReturn(realmResource);
     when(realmResource.clients().create(clientCaptor.capture())).thenReturn(clientResponse);
@@ -111,7 +111,7 @@ class LoginClientServiceTest {
   void setupClient_negative_failedToCreateClient() {
     var internalServerError = new ServerResponse(null, 500, new Headers<>());
 
-    when(keycloakRealmSetupProperties.getLoginClient()).thenReturn(loginClientProperties());
+    when(keycloakRealmSetupProperties.getLoginClientId(TENANT_NAME)).thenReturn(CLIENT_ID);
     when(clientSecretService.getOrCreateClientSecret(TENANT_NAME, CLIENT_ID)).thenReturn(CLIENT_SECRET);
     when(keycloak.realm(TENANT_NAME)).thenReturn(realmResource);
     when(realmResource.clients().create(clientCaptor.capture())).thenReturn(internalServerError);
@@ -129,7 +129,7 @@ class LoginClientServiceTest {
 
   @Test
   void setupClient_negative_failedToCreateClientWithException() {
-    when(keycloakRealmSetupProperties.getLoginClient()).thenReturn(loginClientProperties());
+    when(keycloakRealmSetupProperties.getLoginClientId(TENANT_NAME)).thenReturn(CLIENT_ID);
     when(clientSecretService.getOrCreateClientSecret(TENANT_NAME, CLIENT_ID)).thenReturn(CLIENT_SECRET);
     when(keycloak.realm(TENANT_NAME)).thenReturn(realmResource);
     when(realmResource.clients().create(clientCaptor.capture())).thenThrow(InternalServerErrorException.class);
@@ -144,12 +144,6 @@ class LoginClientServiceTest {
 
     verify(realmResource, atLeastOnce()).clients();
     verify(jsonHelper, times(4)).asJsonString(any());
-  }
-
-  private static KeycloakClientProperties loginClientProperties() {
-    var keycloakClientProperties = new KeycloakClientProperties();
-    keycloakClientProperties.setClientId("-test-app");
-    return keycloakClientProperties;
   }
 
   private static Headers<Object> responseHeaders() {
@@ -172,7 +166,7 @@ class LoginClientServiceTest {
     keycloakClient.setClientAuthenticatorType("client-secret");
     keycloakClient.setAttributes(new ClientAttributes(false, false, 0L, true, false, true, null, null).asMap());
     keycloakClient.setProtocolMappers(List.of(usernameProtocolMapper(), userIdProtocolMapper(),
-      subjectProtocolMapper()));
+      subjectProtocolMapper(), audienceProtocolMapper(CLIENT_ID)));
     keycloakClient.setServiceAccountsEnabled(true);
     keycloakClient.setDirectAccessGrantsEnabled(true);
     keycloakClient.setRedirectUris(List.of("/*"));

--- a/src/test/java/org/folio/tm/it/KeycloakInteractionsIT.java
+++ b/src/test/java/org/folio/tm/it/KeycloakInteractionsIT.java
@@ -27,6 +27,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Supplier;
+import java.util.stream.StreamSupport;
 import lombok.SneakyThrows;
 import org.apache.commons.collections4.CollectionUtils;
 import org.folio.test.extensions.EnableKeycloakDataImport;
@@ -109,13 +110,15 @@ class KeycloakInteractionsIT extends BaseIntegrationTest {
 
   @Test
   void userAuthorizationCheck() {
-    var clientCredentials = ClientCredentials.of(TENANT + "-login-application", "supersecret");
+    var loginClientId = TENANT + "-login-application";
+    var clientCredentials = ClientCredentials.of(loginClientId, "supersecret");
     var loginCredentials = UserCredentials.of("test_user", "test_user-password");
     var accessToken = kcTestClient.login(TENANT, loginCredentials.asTokenRequestBody(clientCredentials));
 
     var parsedTokenTree = parseToken(accessToken);
     assertThat(parsedTokenTree.path("sub").asText()).isEqualTo("test_user");
     assertThat(parsedTokenTree.path("user_id").asText()).isEqualTo(FOLIO_USER_ID);
+    assertThat(audienceClaim(parsedTokenTree)).contains(loginClientId);
 
     assertThat(kcTestClient.verifyToken(TENANT, accessToken, "/bar/entities#GET")).isEqualTo(FORBIDDEN);
     assertThat(kcTestClient.verifyToken(TENANT, accessToken, "/foo/entities#GET")).isEqualTo(OK);
@@ -132,12 +135,39 @@ class KeycloakInteractionsIT extends BaseIntegrationTest {
     var parsedTokenTree = parseToken(accessToken);
     assertThat(parsedTokenTree.path("sub").asText()).isEqualTo("test_user");
     assertThat(parsedTokenTree.path("user_id").asText()).isEqualTo(FOLIO_USER_ID);
+    assertThat(audienceClaim(parsedTokenTree)).contains(TENANT + "-login-application");
 
     assertThat(kcTestClient.verifyToken(TENANT, accessToken, "/bar/entities#GET")).isEqualTo(FORBIDDEN);
     assertThat(kcTestClient.verifyToken(TENANT, accessToken, "/foo/entities#GET")).isEqualTo(OK);
     assertThat(kcTestClient.verifyToken(TENANT, accessToken, "/foo/entities/{id}#GET")).isEqualTo(FORBIDDEN);
     assertThat(kcTestClient.verifyToken(TENANT, accessToken, "/foo/entities/{id}#PUT")).isEqualTo(FORBIDDEN);
     assertThat(kcTestClient.verifyToken(TENANT, accessToken, "/foo/entities/{id}#DELETE")).isEqualTo(FORBIDDEN);
+  }
+
+  @Test
+  void loginClientCanIntrospectUserToken() {
+    var loginClientId = TENANT + "-login-application";
+    var clientCredentials = ClientCredentials.of(loginClientId, "supersecret");
+    var loginCredentials = UserCredentials.of("test_user", "test_user-password");
+    var accessToken = kcTestClient.login(TENANT, loginCredentials.asTokenRequestBody(clientCredentials));
+
+    var introspectionResult = kcTestClient.introspectToken(TENANT, clientCredentials, accessToken);
+
+    assertThat(introspectionResult.path("active").asBoolean()).isTrue();
+    assertThat(audienceClaim(introspectionResult)).contains(loginClientId);
+  }
+
+  @Test
+  void loginClientCanIntrospectImpersonatedToken() {
+    var loginClientId = TENANT + "-login-application";
+    var impersonationClientCredentials = ClientCredentials.of("impersonation-client", "supersecret");
+    var accessToken = kcTestClient.impersonateUser(TENANT, "test_user", impersonationClientCredentials);
+
+    var loginClientCredentials = ClientCredentials.of(loginClientId, "supersecret");
+    var introspectionResult = kcTestClient.introspectToken(TENANT, loginClientCredentials, accessToken);
+
+    assertThat(introspectionResult.path("active").asBoolean()).isTrue();
+    assertThat(audienceClaim(introspectionResult)).contains(loginClientId);
   }
 
   @Test
@@ -249,5 +279,14 @@ class KeycloakInteractionsIT extends BaseIntegrationTest {
     var parts = accessToken.split("\\.");
     assertThat(parts).hasSize(3);
     return OBJECT_MAPPER.readTree(Base64.getDecoder().decode(parts[1]));
+  }
+
+  private static List<String> audienceClaim(JsonNode token) {
+    var audience = token.path("aud");
+    if (audience.isArray()) {
+      return StreamSupport.stream(audience.spliterator(), false).map(JsonNode::asText).toList();
+    }
+
+    return List.of(audience.asText());
   }
 }

--- a/src/test/java/org/folio/tm/it/TenantKeycloakIT.java
+++ b/src/test/java/org/folio/tm/it/TenantKeycloakIT.java
@@ -7,6 +7,7 @@ import static org.folio.tm.domain.dto.TenantType.VIRTUAL;
 import static org.folio.tm.integration.keycloak.model.ProtocolMapper.USER_ATTRIBUTE_MAPPER_TYPE;
 import static org.folio.tm.integration.keycloak.model.ProtocolMapper.USER_PROPERTY_MAPPER_TYPE;
 import static org.folio.tm.support.TestConstants.TENANT_ID;
+import static org.folio.tm.support.TestConstants.audienceProtocolMapper;
 import static org.folio.tm.support.TestConstants.protocolMapper;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
@@ -125,6 +126,7 @@ class TenantKeycloakIT extends BaseIntegrationTest {
     assertThat(realm.getClientSessionMaxLifespan()).isEqualTo(keycloakRealmProps.getClientSession().getMaxLifespan());
 
     checkImpersonationClient(tenantName);
+    checkLoginClient(tenantName);
   }
 
   @Test
@@ -145,6 +147,7 @@ class TenantKeycloakIT extends BaseIntegrationTest {
     var realm = keycloakTestClient.getRealm(tenantName);
     assertThat(realm.getRealm()).isEqualTo(tenantName);
     checkImpersonationClient(tenantName);
+    checkLoginClient(tenantName);
     assertThat(realm.getAccessTokenLifespan()).isEqualTo(261);
     assertThat(realm.getSsoSessionIdleTimeout()).isEqualTo(262);
     assertThat(realm.getSsoSessionMaxLifespan()).isEqualTo(263);
@@ -302,5 +305,22 @@ class TenantKeycloakIT extends BaseIntegrationTest {
       .usingRecursiveComparison()
       .ignoringFields("id")
       .isEqualTo(protocolMapper(USER_ATTRIBUTE_MAPPER_TYPE, "user_id mapper", "user_id", "user_id"));
+
+    assertThat(getMapperByName(mappers, "audience mapper"))
+      .usingRecursiveComparison()
+      .ignoringFields("id")
+      .isEqualTo(audienceProtocolMapper(keycloakRealmProps.getLoginClientId(tenantName)));
+  }
+
+  private void checkLoginClient(String tenantName) {
+    var loginClientId = keycloakRealmProps.getLoginClientId(tenantName);
+    var client = keycloakTestClient.findClientByClientId(tenantName, loginClientId);
+    assertThat(client).isPresent();
+
+    var mappers = client.get().getProtocolMappers();
+    assertThat(getMapperByName(mappers, "audience mapper"))
+      .usingRecursiveComparison()
+      .ignoringFields("id")
+      .isEqualTo(audienceProtocolMapper(loginClientId));
   }
 }

--- a/src/test/java/org/folio/tm/support/KeycloakTestClientConfiguration.java
+++ b/src/test/java/org/folio/tm/support/KeycloakTestClientConfiguration.java
@@ -30,6 +30,7 @@ import org.keycloak.representations.idm.RealmRepresentation;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.HttpStatus;
+import tools.jackson.databind.JsonNode;
 
 @Log4j2
 @TestConfiguration
@@ -97,6 +98,26 @@ public class KeycloakTestClientConfiguration {
 
       var response = HTTP_CLIENT_DUMMY_SSL.send(request, BodyHandlers.ofString(UTF_8));
       return HttpStatus.resolve(response.statusCode());
+    }
+
+    @SneakyThrows
+    public JsonNode introspectToken(String tenant, ClientCredentials clientCredentials, String token) {
+      var keycloakBaseUrl = Strings.CS.removeEnd(keycloakConfiguration.getUrl(), "/");
+      var uri = URI.create(
+        String.format("%s/realms/%s/protocol/openid-connect/token/introspect", keycloakBaseUrl, tenant));
+      var requestBody = Map.of(
+        "client_id", clientCredentials.getClientId(),
+        "client_secret", clientCredentials.getClientSecret(),
+        "token", token);
+
+      var request = HttpRequest.newBuilder(uri)
+        .method("POST", ofString(toFormUrlencodedValue(requestBody), UTF_8))
+        .header(CONTENT_TYPE, APPLICATION_FORM_URLENCODED_VALUE)
+        .build();
+
+      var response = HTTP_CLIENT_DUMMY_SSL.send(request, BodyHandlers.ofString(UTF_8));
+      assertThat(response.statusCode()).isLessThan(400);
+      return OBJECT_MAPPER.readTree(response.body());
     }
 
     @SneakyThrows

--- a/src/test/java/org/folio/tm/support/TestConstants.java
+++ b/src/test/java/org/folio/tm/support/TestConstants.java
@@ -2,11 +2,19 @@ package org.folio.tm.support;
 
 import static org.folio.tm.domain.dto.TenantType.DEFAULT;
 import static org.folio.tm.integration.keycloak.model.Client.OPENID_CONNECT_PROTOCOL;
+import static org.folio.tm.integration.keycloak.model.ProtocolMapper.AUDIENCE_MAPPER_TYPE;
 import static org.folio.tm.integration.keycloak.model.ProtocolMapper.SUB_MAPPER_TYPE;
 import static org.folio.tm.integration.keycloak.model.ProtocolMapper.USER_ATTRIBUTE_MAPPER_TYPE;
+import static org.folio.tm.integration.keycloak.model.ProtocolMapperConfig.ACCESS_TOKEN_CLAIM;
+import static org.folio.tm.integration.keycloak.model.ProtocolMapperConfig.ID_TOKEN_CLAIM;
+import static org.folio.tm.integration.keycloak.model.ProtocolMapperConfig.INCLUDED_CLIENT_AUDIENCE;
+import static org.folio.tm.integration.keycloak.model.ProtocolMapperConfig.INTROSPECTION_TOKEN_CLAIM;
+import static org.folio.tm.integration.keycloak.model.ProtocolMapperConfig.LIGHTWEIGHT_CLAIM;
+import static org.folio.tm.integration.keycloak.model.ProtocolMapperConfig.USERINFO_TOKEN_CLAIM;
 import static org.folio.tm.integration.keycloak.model.ProtocolMapperConfig.forUserAttribute;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -78,6 +86,22 @@ public class TestConstants {
     subjectMapper.setConfig(ProtocolMapperConfig.defaultValue().asMap());
 
     return subjectMapper;
+  }
+
+  public static ProtocolMapperRepresentation audienceProtocolMapper(String clientId) {
+    var audienceMapper = new ProtocolMapperRepresentation();
+    audienceMapper.setName("audience mapper");
+    audienceMapper.setProtocolMapper(AUDIENCE_MAPPER_TYPE);
+    audienceMapper.setProtocol(OPENID_CONNECT_PROTOCOL);
+    audienceMapper.setConfig(Map.of(
+      INCLUDED_CLIENT_AUDIENCE, clientId,
+      ID_TOKEN_CLAIM, "false",
+      ACCESS_TOKEN_CLAIM, "true",
+      USERINFO_TOKEN_CLAIM, "false",
+      LIGHTWEIGHT_CLAIM, "true",
+      INTROSPECTION_TOKEN_CLAIM, "true"));
+
+    return audienceMapper;
   }
 
   public static ProtocolMapperRepresentation protocolMapper(String mapperType,


### PR DESCRIPTION
## Purpose

Keycloak 26.6 introduced a breaking change where token introspection validates that the introspecting client is present in the token `aud` claim, which broke flows such as switching the active affiliation in consortia; this change configures tokens for newly created tenants so the audience check passes without the temporary `KC_SPI_LOGIN_PROTOCOL__OPENID_CONNECT__ALLOW_TOKEN_INTROSPECTION_WITHOUT_AUDIENCE_CHECK` compatibility flag.

US: [MGRTENANT-94](https://folio-org.atlassian.net/browse/MGRTENANT-94)

## Approach

When a new tenant realm is created, an `oidc-audience-mapper` is now attached to the clients that issue user access tokens, so every issued token carries the tenant login client (`{tenant}-login-application`) in its `aud` claim. The mapper opts into lightweight access tokens (the login client has `client.use.lightweight.access.token.enabled=true`), and since protocol mappers are embedded in the one-time client-create request, re-running tenant setup cannot create duplicate mappers.

- Introduced `KeycloakClientUtils.getAudienceProtocolMapper(clientId)` building an `oidc-audience-mapper` with `included.client.audience={clientId}`, `access.token.claim=true`, `lightweight.claim=true` and `introspection.token.claim=true`. The `lightweight.claim` option is required so the `aud` claim survives in lightweight access tokens.
- Changed `AbstractKeycloakClientService.getProtocolMappers()` to `getProtocolMappers(realm, clientId)` so client services can build realm-scoped mapper configuration.
- Added the audience mapper to `LoginClientService` with the login client's own id as the audience.
- Added the audience mapper to `ImpersonationClientService` with the tenant login client id as the audience, because user tokens issued via token exchange (consortia affiliation switching, scheduled jobs) are introspected by the login client.
- Introduced `KeycloakRealmSetupProperties.getLoginClientId(realm)` as the single source for deriving the login client id and reused it in `LoginClientService`.
- Added the `AUDIENCE_MAPPER_TYPE`, `INCLUDED_CLIENT_AUDIENCE` and `INTROSPECTION_TOKEN_CLAIM` constants to the protocol mapper model classes.

## Pre-Review Checklist

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Dependent module build verification** — Ran manually when library changes impact downstream modules.
  > Actions → Verify Dependent Modules → Run workflow → select branch → Run.
- [ ] **Breaking Changes (if any)** — Handled if changes affect integration with other services.
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
