### PR TITLE
MGRTENANT-95: Prevent users from managing their own user attributes in Keycloak

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 * Upgrade dependencies for Kafka 4.2 compatibility in mgr-tenants (MGRTENANT-91)
 * Switch Kong integration test container to folioci/folio-kong image (APPPOCTOOL-37)
 * Add audience protocol mapper to the tenant login and impersonation clients so issued access tokens contain the login client in `aud` (MGRTENANT-94)
+* Enforce Keycloak user-profile `unmanagedAttributePolicy=ADMIN_EDIT` on tenant realms during provisioning and via idempotent startup migration (MGRTENANT-95)
 
 ---
 

--- a/src/main/java/org/folio/tm/integration/keycloak/KeycloakRealmService.java
+++ b/src/main/java/org/folio/tm/integration/keycloak/KeycloakRealmService.java
@@ -25,6 +25,7 @@ import org.keycloak.common.util.MultivaluedHashMap;
 import org.keycloak.representations.idm.ComponentExportRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.RequiredActionProviderRepresentation;
+import org.keycloak.representations.userprofile.config.UPConfig.UnmanagedAttributePolicy;
 import org.springframework.util.Assert;
 import tools.jackson.core.type.TypeReference;
 
@@ -119,6 +120,28 @@ public class KeycloakRealmService {
     } catch (WebApplicationException exception) {
       throw new KeycloakException("Failed to find Keycloak realm by name: " + name, exception);
     }
+  }
+
+  /**
+   * Ensures the realm's user-profile unmanagedAttributePolicy is ADMIN_EDIT (MGRTENANT-95).
+   *
+   * <p>Fetches the full user-profile configuration and updates only the policy field, preserving
+   * attribute and group definitions. {@link NotFoundException} propagates so callers can
+   * distinguish a missing realm from an update failure.</p>
+   *
+   * @param realmName - Keycloak realm name
+   * @return true if the policy was updated, false if it was already ADMIN_EDIT
+   */
+  public boolean ensureUnmanagedAttributePolicy(String realmName) {
+    var userProfileResource = keycloak.realm(realmName).users().userProfile();
+    var config = userProfileResource.getConfiguration();
+    if (config.getUnmanagedAttributePolicy() == UnmanagedAttributePolicy.ADMIN_EDIT) {
+      return false;
+    }
+
+    config.setUnmanagedAttributePolicy(UnmanagedAttributePolicy.ADMIN_EDIT);
+    userProfileResource.update(config);
+    return true;
   }
 
   @SuppressWarnings("checkstyle:MethodLength")

--- a/src/main/java/org/folio/tm/integration/keycloak/KeycloakRealmService.java
+++ b/src/main/java/org/folio/tm/integration/keycloak/KeycloakRealmService.java
@@ -123,7 +123,7 @@ public class KeycloakRealmService {
   }
 
   /**
-   * Ensures the realm's user-profile unmanagedAttributePolicy is ADMIN_EDIT (MGRTENANT-95).
+   * Ensures the realm's user-profile unmanagedAttributePolicy is ADMIN_EDIT.
    *
    * <p>Fetches the full user-profile configuration and updates only the policy field, preserving
    * attribute and group definitions. {@link NotFoundException} propagates so callers can

--- a/src/main/java/org/folio/tm/integration/keycloak/configuration/KeycloakConfiguration.java
+++ b/src/main/java/org/folio/tm/integration/keycloak/configuration/KeycloakConfiguration.java
@@ -13,6 +13,7 @@ import org.folio.tm.integration.keycloak.KeycloakClient;
 import org.folio.tm.integration.keycloak.KeycloakRealmService;
 import org.folio.tm.integration.keycloak.KeycloakServerInfoService;
 import org.folio.tm.integration.keycloak.KeycloakTenantListener;
+import org.folio.tm.integration.keycloak.migration.UnmanagedAttributePolicyMigration;
 import org.folio.tm.integration.keycloak.service.clients.ImpersonationClientService;
 import org.folio.tm.integration.keycloak.service.clients.KeycloakClientService;
 import org.folio.tm.integration.keycloak.service.clients.LoginClientService;
@@ -21,6 +22,7 @@ import org.folio.tm.integration.keycloak.service.clients.PasswordResetClientServ
 import org.folio.tm.integration.keycloak.service.roles.KeycloakRealmRoleService;
 import org.folio.tm.integration.keycloak.service.roles.PasswordResetRoleService;
 import org.folio.tm.integration.keycloak.service.roles.SystemRoleService;
+import org.folio.tm.repository.TenantRepository;
 import org.folio.tm.utils.JsonHelper;
 import org.folio.tools.store.SecureStore;
 import org.folio.tools.store.exception.SecretNotFoundException;
@@ -75,6 +77,12 @@ public class KeycloakConfiguration {
   @Bean
   public KeycloakTenantListener keycloakTenantListener(KeycloakRealmService keycloakRealmService) {
     return new KeycloakTenantListener(keycloakRealmService);
+  }
+
+  @Bean
+  public UnmanagedAttributePolicyMigration unmanagedAttributePolicyMigration(
+    TenantRepository tenantRepository, KeycloakRealmService keycloakRealmService) {
+    return new UnmanagedAttributePolicyMigration(tenantRepository, keycloakRealmService);
   }
 
   @Bean

--- a/src/main/java/org/folio/tm/integration/keycloak/migration/UnmanagedAttributePolicyMigration.java
+++ b/src/main/java/org/folio/tm/integration/keycloak/migration/UnmanagedAttributePolicyMigration.java
@@ -10,19 +10,16 @@ import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 
 /**
- * Startup migration enforcing the Keycloak user-profile {@code unmanagedAttributePolicy=ADMIN_EDIT}
- * on all existing tenant realms (MGRTENANT-95, SECURITY-1029 remediation).
- *
- * <p>Idempotent: realms already having ADMIN_EDIT are not updated. A failure for one realm is
+ * Idempotent: realms already having ADMIN_EDIT are not updated. A failure for one realm is
  * logged with the {@link #LOG_MARKER} and does not stop the migration for remaining realms.
  * Only realms of tenants managed by this module are touched, so the {@code master} realm and
- * any non-tenant realms are never affected.</p>
+ * any non-tenant realms are never affected.
  */
 @Log4j2
 @RequiredArgsConstructor
 public class UnmanagedAttributePolicyMigration implements ApplicationRunner {
 
-  static final String LOG_MARKER = "MGRTENANT-95";
+  static final String LOG_MARKER = "REALM SETTINGS MIGRATION";
   private static final String MASTER_REALM = "master";
 
   private final TenantRepository tenantRepository;

--- a/src/main/java/org/folio/tm/integration/keycloak/migration/UnmanagedAttributePolicyMigration.java
+++ b/src/main/java/org/folio/tm/integration/keycloak/migration/UnmanagedAttributePolicyMigration.java
@@ -1,0 +1,102 @@
+package org.folio.tm.integration.keycloak.migration;
+
+import jakarta.ws.rs.NotFoundException;
+import java.util.EnumMap;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.folio.tm.integration.keycloak.KeycloakRealmService;
+import org.folio.tm.repository.TenantRepository;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+
+/**
+ * Startup migration enforcing the Keycloak user-profile {@code unmanagedAttributePolicy=ADMIN_EDIT}
+ * on all existing tenant realms (MGRTENANT-95, SECURITY-1029 remediation).
+ *
+ * <p>Idempotent: realms already having ADMIN_EDIT are not updated. A failure for one realm is
+ * logged with the {@link #LOG_MARKER} and does not stop the migration for remaining realms.
+ * Only realms of tenants managed by this module are touched, so the {@code master} realm and
+ * any non-tenant realms are never affected.</p>
+ */
+@Log4j2
+@RequiredArgsConstructor
+public class UnmanagedAttributePolicyMigration implements ApplicationRunner {
+
+  static final String LOG_MARKER = "MGRTENANT-95";
+  private static final String MASTER_REALM = "master";
+
+  private final TenantRepository tenantRepository;
+  private final KeycloakRealmService keycloakRealmService;
+
+  @Override
+  public void run(ApplicationArguments args) {
+    try {
+      migrate();
+    } catch (Exception exception) {
+      log.error("{}: unmanaged attribute policy migration failed to complete", LOG_MARKER, exception);
+    }
+  }
+
+  /**
+   * Applies the ADMIN_EDIT policy to every tenant realm that does not have it yet.
+   *
+   * @return migration {@link Summary} with per-outcome counts
+   */
+  public Summary migrate() {
+    var tenants = tenantRepository.findAll().stream()
+      .filter(tenant -> !MASTER_REALM.equals(tenant.getName()))
+      .toList();
+    log.info("{}: enforcing user-profile unmanagedAttributePolicy=ADMIN_EDIT on {} tenant realm(s)",
+      LOG_MARKER, tenants.size());
+
+    var counters = new EnumMap<Outcome, Integer>(Outcome.class);
+    for (var tenant : tenants) {
+      counters.merge(enforceForRealm(tenant.getName()), 1, Integer::sum);
+    }
+
+    var summary = new Summary(tenants.size(),
+      counters.getOrDefault(Outcome.UPDATED, 0), counters.getOrDefault(Outcome.ALREADY_COMPLIANT, 0),
+      counters.getOrDefault(Outcome.MISSING, 0), counters.getOrDefault(Outcome.FAILED, 0));
+    log.info("{}: migration finished [scanned: {}, updated: {}, alreadyCompliant: {}, missing: {}, failed: {}]",
+      LOG_MARKER, summary.scanned(), summary.updated(), summary.alreadyCompliant(), summary.missing(),
+      summary.failed());
+    return summary;
+  }
+
+  private Outcome enforceForRealm(String realmName) {
+    try {
+      if (keycloakRealmService.ensureUnmanagedAttributePolicy(realmName)) {
+        log.info("{}: realm '{}': unmanagedAttributePolicy updated to ADMIN_EDIT", LOG_MARKER, realmName);
+        return Outcome.UPDATED;
+      }
+
+      log.debug("{}: realm '{}': already ADMIN_EDIT, skipping", LOG_MARKER, realmName);
+      return Outcome.ALREADY_COMPLIANT;
+    } catch (NotFoundException exception) {
+      log.warn("{}: realm '{}' not found in Keycloak, skipping", LOG_MARKER, realmName);
+      return Outcome.MISSING;
+    } catch (Exception exception) {
+      return logFailure(realmName, exception);
+    }
+  }
+
+  private Outcome logFailure(String realmName, Exception exception) {
+    log.error("{}: failed to enforce ADMIN_EDIT for realm '{}'", LOG_MARKER, realmName, exception);
+    return Outcome.FAILED;
+  }
+
+  /**
+   * Aggregate result of a migration run.
+   *
+   * @param scanned          - number of tenants read from the database
+   * @param updated          - realms updated to ADMIN_EDIT
+   * @param alreadyCompliant - realms already having ADMIN_EDIT
+   * @param missing          - tenants without a Keycloak realm
+   * @param failed           - realms that failed to update
+   */
+  public record Summary(int scanned, int updated, int alreadyCompliant, int missing, int failed) {}
+
+  enum Outcome {
+    UPDATED, ALREADY_COMPLIANT, MISSING, FAILED
+  }
+}

--- a/src/main/resources/json/realms/user-profile-configuration.json
+++ b/src/main/resources/json/realms/user-profile-configuration.json
@@ -68,5 +68,5 @@
       "displayDescription": "Attributes, which refer to user metadata"
     }
   ],
-  "unmanagedAttributePolicy": "ENABLED"
+  "unmanagedAttributePolicy": "ADMIN_EDIT"
 }

--- a/src/test/java/org/folio/tm/integration/keycloak/KeycloakRealmServiceTest.java
+++ b/src/test/java/org/folio/tm/integration/keycloak/KeycloakRealmServiceTest.java
@@ -7,6 +7,7 @@ import static org.folio.tm.support.TestConstants.TENANT_NAME;
 import static org.folio.tm.support.TestUtils.OBJECT_MAPPER;
 import static org.folio.tm.support.TestUtils.readString;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -40,12 +41,17 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.admin.client.resource.RealmsResource;
+import org.keycloak.admin.client.resource.UserProfileResource;
+import org.keycloak.admin.client.resource.UsersResource;
 import org.keycloak.admin.client.token.TokenManager;
 import org.keycloak.common.util.MultivaluedHashMap;
 import org.keycloak.representations.AccessTokenResponse;
 import org.keycloak.representations.idm.ComponentExportRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.RequiredActionProviderRepresentation;
+import org.keycloak.representations.userprofile.config.UPAttribute;
+import org.keycloak.representations.userprofile.config.UPConfig;
+import org.keycloak.representations.userprofile.config.UPConfig.UnmanagedAttributePolicy;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -73,6 +79,8 @@ class KeycloakRealmServiceTest {
   @Mock private RealmResource realmResource;
   @Mock private RealmsResource realmsResource;
   @Mock private AccessTokenResponse accessTokenResponse;
+  @Mock private UsersResource usersResource;
+  @Mock private UserProfileResource userProfileResource;
 
   @BeforeEach
   void setUp() {
@@ -423,6 +431,75 @@ class KeycloakRealmServiceTest {
         .isInstanceOf(KeycloakException.class)
         .hasMessage("Failed to find Keycloak realm by name: " + TENANT_NAME)
         .hasCauseInstanceOf(InternalServerErrorException.class);
+    }
+  }
+
+  @Nested
+  @DisplayName("ensureUnmanagedAttributePolicy")
+  class EnsureUnmanagedAttributePolicy {
+
+    @Test
+    void positive() {
+      var config = userProfileConfig(UnmanagedAttributePolicy.ENABLED);
+      mockUserProfileResource();
+      when(userProfileResource.getConfiguration()).thenReturn(config);
+
+      var result = keycloakRealmService.ensureUnmanagedAttributePolicy(TENANT_NAME);
+
+      assertThat(result).isTrue();
+      assertThat(config.getUnmanagedAttributePolicy()).isEqualTo(UnmanagedAttributePolicy.ADMIN_EDIT);
+      assertThat(config.getAttributes()).extracting(UPAttribute::getName).containsExactly("username");
+      verify(userProfileResource).update(same(config));
+    }
+
+    @Test
+    void positive_nullPolicy() {
+      var config = userProfileConfig(null);
+      mockUserProfileResource();
+      when(userProfileResource.getConfiguration()).thenReturn(config);
+
+      var result = keycloakRealmService.ensureUnmanagedAttributePolicy(TENANT_NAME);
+
+      assertThat(result).isTrue();
+      assertThat(config.getUnmanagedAttributePolicy()).isEqualTo(UnmanagedAttributePolicy.ADMIN_EDIT);
+      verify(userProfileResource).update(same(config));
+    }
+
+    @Test
+    void positive_alreadyAdminEdit() {
+      var config = userProfileConfig(UnmanagedAttributePolicy.ADMIN_EDIT);
+      mockUserProfileResource();
+      when(userProfileResource.getConfiguration()).thenReturn(config);
+
+      var result = keycloakRealmService.ensureUnmanagedAttributePolicy(TENANT_NAME);
+
+      assertThat(result).isFalse();
+      assertThat(config.getUnmanagedAttributePolicy()).isEqualTo(UnmanagedAttributePolicy.ADMIN_EDIT);
+      verify(userProfileResource, never()).update(any());
+    }
+
+    @Test
+    void negative_realmNotFound() {
+      mockUserProfileResource();
+      when(userProfileResource.getConfiguration()).thenThrow(NotFoundException.class);
+
+      assertThatThrownBy(() -> keycloakRealmService.ensureUnmanagedAttributePolicy(TENANT_NAME))
+        .isInstanceOf(NotFoundException.class);
+
+      verify(userProfileResource, never()).update(any());
+    }
+
+    private void mockUserProfileResource() {
+      when(keycloak.realm(TENANT_NAME)).thenReturn(realmResource);
+      when(realmResource.users()).thenReturn(usersResource);
+      when(usersResource.userProfile()).thenReturn(userProfileResource);
+    }
+
+    private static UPConfig userProfileConfig(UnmanagedAttributePolicy policy) {
+      var config = new UPConfig();
+      config.setAttributes(List.of(new UPAttribute("username")));
+      config.setUnmanagedAttributePolicy(policy);
+      return config;
     }
   }
 }

--- a/src/test/java/org/folio/tm/integration/keycloak/migration/UnmanagedAttributePolicyMigrationTest.java
+++ b/src/test/java/org/folio/tm/integration/keycloak/migration/UnmanagedAttributePolicyMigrationTest.java
@@ -1,0 +1,117 @@
+package org.folio.tm.integration.keycloak.migration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import jakarta.ws.rs.NotFoundException;
+import java.util.List;
+import org.folio.test.types.UnitTest;
+import org.folio.tm.domain.entity.TenantEntity;
+import org.folio.tm.integration.keycloak.KeycloakRealmService;
+import org.folio.tm.integration.keycloak.migration.UnmanagedAttributePolicyMigration.Summary;
+import org.folio.tm.repository.TenantRepository;
+import org.folio.tm.support.TestUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@UnitTest
+@ExtendWith(MockitoExtension.class)
+class UnmanagedAttributePolicyMigrationTest {
+
+  @InjectMocks private UnmanagedAttributePolicyMigration migration;
+
+  @Mock private TenantRepository tenantRepository;
+  @Mock private KeycloakRealmService keycloakRealmService;
+
+  @AfterEach
+  void tearDown() {
+    TestUtils.verifyNoMoreInteractions(this);
+  }
+
+  @Test
+  void migrate_positive() {
+    when(tenantRepository.findAll()).thenReturn(tenants("tenant1", "tenant2", "tenant3", "tenant4"));
+    when(keycloakRealmService.ensureUnmanagedAttributePolicy("tenant1")).thenReturn(true);
+    when(keycloakRealmService.ensureUnmanagedAttributePolicy("tenant2")).thenThrow(new RuntimeException("error"));
+    when(keycloakRealmService.ensureUnmanagedAttributePolicy("tenant3")).thenThrow(NotFoundException.class);
+    when(keycloakRealmService.ensureUnmanagedAttributePolicy("tenant4")).thenReturn(false);
+
+    var result = migration.migrate();
+
+    assertThat(result).isEqualTo(new Summary(4, 1, 1, 1, 1));
+    var order = inOrder(keycloakRealmService);
+    order.verify(keycloakRealmService).ensureUnmanagedAttributePolicy("tenant1");
+    order.verify(keycloakRealmService).ensureUnmanagedAttributePolicy("tenant2");
+    order.verify(keycloakRealmService).ensureUnmanagedAttributePolicy("tenant3");
+    order.verify(keycloakRealmService).ensureUnmanagedAttributePolicy("tenant4");
+  }
+
+  @Test
+  void migrate_positive_allCompliant() {
+    when(tenantRepository.findAll()).thenReturn(tenants("tenant1", "tenant2"));
+    when(keycloakRealmService.ensureUnmanagedAttributePolicy("tenant1")).thenReturn(false);
+    when(keycloakRealmService.ensureUnmanagedAttributePolicy("tenant2")).thenReturn(false);
+
+    var result = migration.migrate();
+
+    assertThat(result).isEqualTo(new Summary(2, 0, 2, 0, 0));
+  }
+
+  @Test
+  void migrate_positive_masterTenantExcluded() {
+    when(tenantRepository.findAll()).thenReturn(tenants("master", "tenant1"));
+    when(keycloakRealmService.ensureUnmanagedAttributePolicy("tenant1")).thenReturn(true);
+
+    var result = migration.migrate();
+
+    assertThat(result).isEqualTo(new Summary(1, 1, 0, 0, 0));
+    verify(keycloakRealmService, never()).ensureUnmanagedAttributePolicy("master");
+  }
+
+  @Test
+  void migrate_positive_noTenants() {
+    when(tenantRepository.findAll()).thenReturn(List.of());
+
+    var result = migration.migrate();
+
+    assertThat(result).isEqualTo(new Summary(0, 0, 0, 0, 0));
+    verifyNoInteractions(keycloakRealmService);
+  }
+
+  @Test
+  void run_positive() {
+    when(tenantRepository.findAll()).thenReturn(tenants("tenant1"));
+    when(keycloakRealmService.ensureUnmanagedAttributePolicy("tenant1")).thenReturn(true);
+
+    assertThatNoException().isThrownBy(() -> migration.run(null));
+
+    verify(keycloakRealmService).ensureUnmanagedAttributePolicy("tenant1");
+  }
+
+  @Test
+  void run_positive_totalFailureSwallowed() {
+    when(tenantRepository.findAll()).thenThrow(new RuntimeException("database is unavailable"));
+
+    assertThatNoException().isThrownBy(() -> migration.run(null));
+
+    verify(tenantRepository).findAll();
+    verifyNoInteractions(keycloakRealmService);
+  }
+
+  private static List<TenantEntity> tenants(String... names) {
+    return List.of(names).stream().map(name -> {
+      var entity = new TenantEntity();
+      entity.setName(name);
+      return entity;
+    }).toList();
+  }
+}

--- a/src/test/java/org/folio/tm/it/TenantKeycloakIT.java
+++ b/src/test/java/org/folio/tm/it/TenantKeycloakIT.java
@@ -129,7 +129,6 @@ class TenantKeycloakIT extends BaseIntegrationTest {
     checkImpersonationClient(tenantName);
     checkLoginClient(tenantName);
 
-    // MGRTENANT-95: new realms must be provisioned with unmanagedAttributePolicy=ADMIN_EDIT
     assertThat(keycloakTestClient.getUserProfileConfig(tenantName).getUnmanagedAttributePolicy())
       .isEqualTo(UnmanagedAttributePolicy.ADMIN_EDIT);
   }

--- a/src/test/java/org/folio/tm/it/TenantKeycloakIT.java
+++ b/src/test/java/org/folio/tm/it/TenantKeycloakIT.java
@@ -48,6 +48,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.representations.idm.ProtocolMapperRepresentation;
+import org.keycloak.representations.userprofile.config.UPConfig.UnmanagedAttributePolicy;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Import;
@@ -127,6 +128,10 @@ class TenantKeycloakIT extends BaseIntegrationTest {
 
     checkImpersonationClient(tenantName);
     checkLoginClient(tenantName);
+
+    // MGRTENANT-95: new realms must be provisioned with unmanagedAttributePolicy=ADMIN_EDIT
+    assertThat(keycloakTestClient.getUserProfileConfig(tenantName).getUnmanagedAttributePolicy())
+      .isEqualTo(UnmanagedAttributePolicy.ADMIN_EDIT);
   }
 
   @Test

--- a/src/test/java/org/folio/tm/it/UnmanagedAttributePolicyMigrationIT.java
+++ b/src/test/java/org/folio/tm/it/UnmanagedAttributePolicyMigrationIT.java
@@ -1,0 +1,107 @@
+package org.folio.tm.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
+import static org.springframework.test.context.jdbc.SqlMergeMode.MergeMode.MERGE;
+
+import java.util.Objects;
+import org.folio.test.extensions.EnableKeycloakDataImport;
+import org.folio.test.extensions.EnableKeycloakSecurity;
+import org.folio.test.extensions.EnableKeycloakTlsMode;
+import org.folio.test.extensions.KeycloakRealms;
+import org.folio.test.types.IntegrationTest;
+import org.folio.tm.base.BaseIntegrationTest;
+import org.folio.tm.integration.keycloak.migration.UnmanagedAttributePolicyMigration;
+import org.folio.tm.integration.keycloak.migration.UnmanagedAttributePolicyMigration.Summary;
+import org.folio.tm.support.KeycloakTestClientConfiguration;
+import org.folio.tm.support.KeycloakTestClientConfiguration.KeycloakTestClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.representations.userprofile.config.UPAttribute;
+import org.keycloak.representations.userprofile.config.UPConfig.UnmanagedAttributePolicy;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.SqlMergeMode;
+
+@IntegrationTest
+@SqlMergeMode(MERGE)
+@EnableKeycloakTlsMode
+@EnableKeycloakSecurity
+@EnableKeycloakDataImport
+@Import(KeycloakTestClientConfiguration.class)
+@TestPropertySource(properties = "application.okapi.enabled=false")
+@Sql(scripts = "classpath:/sql/clear_tenants.sql", executionPhase = AFTER_TEST_METHOD)
+class UnmanagedAttributePolicyMigrationIT extends BaseIntegrationTest {
+
+  private static final String TENANT1 = "tenant1";
+  private static final String MASTER_REALM = "master";
+
+  @Autowired private UnmanagedAttributePolicyMigration migration;
+  @Autowired private KeycloakTestClient keycloakTestClient;
+
+  @AfterEach
+  void tearDown(@Autowired Keycloak keycloak) {
+    var realms = keycloak.realms().findAll();
+    for (var realm : realms) {
+      var realmName = realm.getRealm();
+      if (!Objects.equals(realmName, MASTER_REALM)) {
+        keycloak.realm(realmName).remove();
+      }
+    }
+  }
+
+  @Test
+  @Sql("classpath:/sql/populate_tenants.sql")
+  @KeycloakRealms(realms = "/json/keycloak/tenant1.json")
+  void migrate_positive_enabledPolicyReplaced() {
+    setPolicy(TENANT1, UnmanagedAttributePolicy.ENABLED);
+    var masterPolicyBefore = keycloakTestClient.getUserProfileConfig(MASTER_REALM).getUnmanagedAttributePolicy();
+
+    var result = migration.migrate();
+
+    // 4 tenants in the database, only tenant1 has a realm: the 3 missing ones must not break the run
+    assertThat(result).isEqualTo(new Summary(4, 1, 0, 3, 0));
+    assertThat(keycloakTestClient.getUserProfileConfig(TENANT1).getUnmanagedAttributePolicy())
+      .isEqualTo(UnmanagedAttributePolicy.ADMIN_EDIT);
+    assertThat(keycloakTestClient.getUserProfileConfig(MASTER_REALM).getUnmanagedAttributePolicy())
+      .isEqualTo(masterPolicyBefore);
+  }
+
+  @Test
+  @Sql("classpath:/sql/populate_tenants.sql")
+  @KeycloakRealms(realms = "/json/keycloak/tenant1.json")
+  void migrate_positive_nullPolicyReplaced() {
+    // a realm imported without user-profile configuration has no unmanaged attribute policy (= disabled)
+    assertThat(keycloakTestClient.getUserProfileConfig(TENANT1).getUnmanagedAttributePolicy()).isNull();
+
+    var result = migration.migrate();
+
+    assertThat(result).isEqualTo(new Summary(4, 1, 0, 3, 0));
+    assertThat(keycloakTestClient.getUserProfileConfig(TENANT1).getUnmanagedAttributePolicy())
+      .isEqualTo(UnmanagedAttributePolicy.ADMIN_EDIT);
+  }
+
+  @Test
+  @Sql("classpath:/sql/populate_tenants.sql")
+  @KeycloakRealms(realms = "/json/keycloak/tenant1.json")
+  void migrate_positive_alreadyAdminEditUnchanged() {
+    setPolicy(TENANT1, UnmanagedAttributePolicy.ADMIN_EDIT);
+    var configBefore = keycloakTestClient.getUserProfileConfig(TENANT1);
+
+    var result = migration.migrate();
+
+    assertThat(result).isEqualTo(new Summary(4, 0, 1, 3, 0));
+    var configAfter = keycloakTestClient.getUserProfileConfig(TENANT1);
+    assertThat(configAfter).isEqualTo(configBefore);
+    assertThat(configAfter.getAttributes()).extracting(UPAttribute::getName).contains("username", "email");
+  }
+
+  private void setPolicy(String realm, UnmanagedAttributePolicy policy) {
+    var config = keycloakTestClient.getUserProfileConfig(realm);
+    config.setUnmanagedAttributePolicy(policy);
+    keycloakTestClient.updateUserProfileConfig(realm, config);
+  }
+}

--- a/src/test/java/org/folio/tm/support/KeycloakTestClientConfiguration.java
+++ b/src/test/java/org/folio/tm/support/KeycloakTestClientConfiguration.java
@@ -27,6 +27,7 @@ import org.folio.security.integration.keycloak.configuration.properties.Keycloak
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.representations.userprofile.config.UPConfig;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.HttpStatus;
@@ -60,6 +61,14 @@ public class KeycloakTestClientConfiguration {
       } catch (NotFoundException exception) {
         throw new AssertionError("Failed to find realm: " + realm, exception);
       }
+    }
+
+    public UPConfig getUserProfileConfig(String realm) {
+      return keycloak.realm(realm).users().userProfile().getConfiguration();
+    }
+
+    public void updateUserProfileConfig(String realm, UPConfig config) {
+      keycloak.realm(realm).users().userProfile().update(config);
     }
 
     public String loginAsFolioAdmin() {


### PR DESCRIPTION
## Purpose

Keycloak's default "Unmanaged attributes" policy of `ENABLED` allows end users to write arbitrary attributes to their own profile, which is dangerous in FOLIO's multi-tenant architecture (SECURITY-1029). This change makes `mgr-tenants` enforce the safe policy `ADMIN_EDIT` ("Only administrators can write") on all tenant realms — both at provisioning time and retroactively for existing realms.

US: [MGRTENANT-95](https://folio-org.atlassian.net/browse/MGRTENANT-95)

## Approach

New tenant realms are provisioned with the safe policy directly through the existing declarative user-profile component, so a realm is never created in a vulnerable state. For realms that already exist, an idempotent startup migration sweeps all tenant realms managed by this module and updates only those whose policy differs, via the Keycloak Admin user-profile API (`GET`/`PUT /admin/realms/{realm}/users/profile`).

- Changed `unmanagedAttributePolicy` from `ENABLED` to `ADMIN_EDIT` in `json/realms/user-profile-configuration.json`, which is applied as the `declarative-user-profile` component during realm creation. New realms are born compliant with no remediation window.
- Added `KeycloakRealmService.ensureUnmanagedAttributePolicy(realmName)` that fetches the realm's full user-profile configuration and, only when the policy is not `ADMIN_EDIT` (including the unset/disabled case), sets it on the fetched `UPConfig` and issues the `PUT`. Mutating the fetched configuration in place preserves all attribute and group definitions.
- Introduced `UnmanagedAttributePolicyMigration` implementing `ApplicationRunner`: on every module startup it iterates tenants from the database and enforces the policy per realm, classifying each as `UPDATED`, `ALREADY_COMPLIANT`, `MISSING` (tenant without a Keycloak realm), or `FAILED`, and logs a final summary. Re-running is cheap and idempotent — compliant realms cost one `GET` and are never written to.
- Added per-realm failure isolation: an error on one realm is logged with the searchable `MGRTENANT-95` marker (realm name + cause) and the migration continues with the remaining realms; a total failure is logged and never aborts module startup.
- Excluded the `master` realm structurally: enumeration is database-driven (never `keycloak.realms().findAll()`), plus an explicit name filter as defense in depth.
- Registered the migration bean in `KeycloakConfiguration`, gated by the existing `application.keycloak.enabled` flag; no new configuration properties are introduced.

## Pre-Review Checklist

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Dependent module build verification** — Ran manually when library changes impact downstream modules.
  > Actions → Verify Dependent Modules → Run workflow → select branch → Run.
- [ ] **Breaking Changes (if any)** — Handled if changes affect integration with other services.
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.
